### PR TITLE
Fix Win64 OpenSSL 3.x library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ OpenSSL 1.1.1
 - openssl.exe
 
 OpenSSL 3.x
-- libcrypto-1_1-x64.dll
-- libssl-1_1-x64.dll
+- libcrypto-3-x64.dll
+- libssl-3-x64.dll
 - openssl.exe
 
 ## Component Reference


### PR DESCRIPTION
README.md has Win64 OpenSSL 3.x libraries listed as

- libcrypto-1_1-x64.dll
- libssl-1_1-x64.dll

That should be
- libcrypto-3-x64.dll
- libssl-3-x64.dll