### PR TITLE
Fix connect issues: hostnames never match

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -4274,7 +4274,7 @@ begin
           begin
             LCertificate := TTaurusTLSX509.Create(Lpeercert, False);
             try
-              if not LHelper.VerifyPeer(LCertificate, 0, LVerifyResult) then
+              if not LHelper.VerifyPeer(LCertificate, fSSLContext.VerifyDepth, LVerifyResult) then
               begin
                 ETaurusTLSCertValidationError.RaiseWithMessage
                   (AnsiStringToString(X509_verify_cert_error_string

--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -4207,7 +4207,7 @@ begin
     {$IFNDEF OPENSSL_NO_TLSEXT}
     { Delphi appears to need the extra AnsiString coerction. Otherwise, only the
       first character to the hostname is passed }
-    LRetCode := SSL_set_tlsext_host_name(fSSL, PIdAnsiChar(LHostName));
+    LRetCode := SSL_set_tlsext_host_name(fSSL, PIdAnsiChar(@LHostName[0]));
     if LRetCode <= 0 then begin
        // RLebeau: for the time being, not raising an exception on error, as I don't
        // know which OpenSSL versions support this extension, and which error code(s)
@@ -4222,7 +4222,7 @@ begin
     if fHostName <> '' then
     begin
       SSL_set_hostflags(fSSL,0);
-      LRetCode := SSL_set1_host(fSSL, PIdAnsiChar( @LHostName));
+      LRetCode := SSL_set1_host(fSSL, PIdAnsiChar( @LHostName[0]));
       if LRetCode <= 0 then
       begin
         ETaurusTLSSettingTLSHostNameError.RaiseException(fSSL, LRetCode,


### PR DESCRIPTION
Hi,

LRetCode := SSL_set1_host(fSSL, PIdAnsiChar( @LHostName));
looks like it passes an address, not content, to PIdAnsiChar, resulting in a garbage hostname.
I guess it should be PIdAnsiChar( @LHostName[0]));
At least that works as far as I can tell.

The other one I'm not sure about, but I would expect to get the VerifyDepth that was set for the connection in a call to VerifyPeer.

Kind regards, Miel.