### PR TITLE
Update tmsbuild.yaml to include url and description

### DIFF
--- a/tmsbuild.yaml
+++ b/tmsbuild.yaml
@@ -3,6 +3,9 @@ minimum required tmsbuild version: 1.8
 application:
   id: taurustls_developers.taurustls
   name: TaurusTLS
+  description: TaurusTLS provides OpenSSL 1.1.1 and 3.x support for Indy - Internet Direct.
+  url: https://github.com/JPeterMugaas/TaurusTLS
+
   version file: version.txt
 
 supported frameworks:


### PR DESCRIPTION
So we can use it in https://github.com/tmssoftware/smartsetup-registry we need the file to have the URL of the repo. 
I also added a description just in case. It won't be used right now, but someday tmsgui could show the descriptions in the list 