### PR TITLE
Fixed nbsp I added by mistake in my previous pull request

### DIFF
--- a/tmsbuild.yaml
+++ b/tmsbuild.yaml
@@ -4,7 +4,7 @@ application:
   id: taurustls_developers.taurustls
   name: TaurusTLS
   description: TaurusTLS provides OpenSSL 1.1.1 and 3.x support for Indy - Internet Direct.
-  url: https://github.com/JPeterMugaas/TaurusTLS
+  url: https://github.com/JPeterMugaas/TaurusTLS
 
   version file: version.txt
 


### PR DESCRIPTION
Sorry, I don't know why, but in my latest pull request I introduced a nbsp (#$A0) instead of a regular space in the url.
This broke tmsbuild.yaml

I've fixed tms.exe so it will work now even with the nbsp, but it is better to fix it anyway, and so it will work until we release the fix.