### PR TITLE
Added: TaurusTLSHeaders_rand.pas -> Default Strength constant from openssl/rand.h

### DIFF
--- a/Source/TaurusTLSHeaders_rand.pas
+++ b/Source/TaurusTLSHeaders_rand.pas
@@ -35,6 +35,10 @@ uses
   {$ENDIF}
   TaurusTLSHeaders_types;
 
+const
+  RAND_DRBG_STRENGTH = 256; // Openssl default RANDOM strength value.
+  RAND_DEFAULT_STRENGTH = RAND_DRBG_STRENGTH;
+
 type
   rand_meth_st_seed = function (const buf: Pointer; num: TIdC_INT): TIdC_INT; cdecl;
   rand_meth_st_bytes = function (buf: PByte; num: TIdC_INT): TIdC_INT; cdecl;


### PR DESCRIPTION
This is a simple change:

`openssl/rand.h` declares a [`RAND_DRBG_STRENGTH`](https://github.com/openssl/openssl/blob/b2ac43b0d89b5b528941ad9d233b4cb4f99a7cca/include/openssl/rand.h#L37C10-L37C28) constant. 
It would be good to have it in the `TaurusTLSHeaders_rand.pas`