### PR TITLE
Added: RAND_DRBG_STRENGTH constant from openssl/rand.h to TaurusTLSHeaders_rand.pas

### DIFF
--- a/Source/TaurusTLSHeaders_rand.pas
+++ b/Source/TaurusTLSHeaders_rand.pas
@@ -35,6 +35,10 @@ uses
   {$ENDIF}
   TaurusTLSHeaders_types;
 
+const
+  RAND_DRBG_STRENGTH = 256; // Openssl default RANDOM strength constant.
+  RAND_DEFAULT_STRENGTH = RAND_DRBG_STRENGTH; // Default RANDOM strength
+
 type
   rand_meth_st_seed = function (const buf: Pointer; num: TIdC_INT): TIdC_INT; cdecl;
   rand_meth_st_bytes = function (buf: PByte; num: TIdC_INT): TIdC_INT; cdecl;


### PR DESCRIPTION
`[openssl/rand.h](https://github.com/openssl/openssl/blob/b2ac43b0d89b5b528941ad9d233b4cb4f99a7cca/include/openssl/rand.h#L37C10-L37C28)` declares `RAND_DRBG_STRENGTH` constant. 
Would be good to have this same constant in the `TaurusTLSHeaders_rand.pas` for consistency.