### PR TITLE
Fixed: inlining for Random methods returning Extended type random value and other corrections

### DIFF
--- a/Source/TaurusTLS_Random.pas
+++ b/Source/TaurusTLS_Random.pas
@@ -244,8 +244,7 @@ type
     ///  <remarks>
     ///  This method returns number in ranges <c>-1 >= x < 0</c> and <c> 0 > x and <=1 </c>
     ///  </remarks>
-    function Random(var AOut: extended): TIdC_INT;
-      overload; {$IFDEF USE_INLINE}inline;{$ENDIF}
+    function Random(var AOut: extended): TIdC_INT; overload;
     ///  <summary>
     ///  The <c>Random</c> is a method to create a <c>generic type</c> <typeparamref name="T" />
     ///  filled with a <c>random</c> value(s);
@@ -375,8 +374,7 @@ type
     ///  <remarks>
     ///  This method returns number in ranges <c>-1 >= x < 0</c> and <c> 0 > x and <=1 </c>
     ///  </remarks>
-    function Random: extended; overload; {$IFDEF USE_INLINE}inline;{$ENDIF}
-
+    function Random: extended; overload;
     ///  <summary>
     ///  The <c>Random</c> is a method to create a <c>generic type</c> <typeparamref name="T" />
     ///  filled with a <c>random</c> value(s);
@@ -437,20 +435,15 @@ type
   ///  </summary>
   ETaurusTLSRandom = class(ETaurusTLSAPICryptoError);
 
-const
-  cMultiplier: extended = ((1.0/$100000000) / $100000000);  // 2^-48
-
-function RandomToExtend(ASeed: TIdC_UINT64): extended;
-  {$IFDEF USE_INLINE}inline;{$ENDIF}
-
 implementation
 
 uses
-  Math,
   TaurusTLSHeaders_err;
 
 function RandomToExtend(ASeed: TIdC_UINT64): extended;
   {$IFDEF USE_INLINE}inline;{$ENDIF}
+const
+  cMultiplier: extended = ((1.0/$100000000) / $100000000);  // 2^-64
 
 var
   lExt: extended;
@@ -458,7 +451,7 @@ var
 begin
   lExt:=ASeed;
   Result:=lExt*cMultiplier;
-  if not IsZero (Result) and (((1 shl (ASeed and $3F)) and ASeed) <> 0) then
+  if not (ASeed <> 0) and (((1 shl (ASeed and $3F)) and ASeed) <> 0) then
     Result:=-1*Result; //random negative
 end;
 
@@ -516,17 +509,18 @@ class destructor TTaurusTLS_OSSLRandom.Destroy;
 begin
   FreeAndNil(FPublicRandom);
   FreeAndNil(FPrivateRandom);
-  inherited Destroy;
 end;
 
 constructor TTaurusTLS_OSSLRandom.Create;
 begin
+  inherited;
   Assert(False, ClassName+' can not be creates with this constructor.');
 end;
 
 destructor TTaurusTLS_OSSLRandom.Destroy;
 begin
   FreeAndNil(FRandomBytes);
+  inherited;
 end;
 
 constructor TTaurusTLS_OSSLRandom.Create(ARandomGen: TTaurusTLS_CustomOSSLRandomBytes;
@@ -606,12 +600,14 @@ end;
 
 constructor TTaurusTLS_Random.Create;
 begin
+  inherited;
   Assert(False, ClassName+' can not be creates with this constructor.');
 end;
 
 destructor TTaurusTLS_Random.Destroy;
 begin
   FreeAndNil(FRandomBytes);
+  inherited;
 end;
 
 procedure TTaurusTLS_Random.CheckError(const AResult: TIdC_INT);

--- a/Tests/TaurusTLS.UT.Random.pas
+++ b/Tests/TaurusTLS.UT.Random.pas
@@ -122,7 +122,7 @@ type
 implementation
 
 uses
-  TaurusTLSHeaders_rand, TaurusTLSHeaders_err;
+  TaurusTLSHeaders_rand, TaurusTLSHeaders_err, TaurusTLSExceptionHandlers;
 
 { TTools }
 

--- a/Tests/TaurusTLS.UT.dproj
+++ b/Tests/TaurusTLS.UT.dproj
@@ -4,7 +4,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Config Condition="'$(Config)'==''">Release</Config>
         <Platform Condition="'$(Platform)'==''">Win64</Platform>
         <TargetedPlatforms>131</TargetedPlatforms>
         <AppType>Console</AppType>
@@ -71,6 +71,12 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Linux64' and '$(Cfg_2)'=='true') or '$(Cfg_2_Linux64)'!=''">
+        <Cfg_2_Linux64>true</Cfg_2_Linux64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
         <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
@@ -87,6 +93,7 @@
         <SanitizedProjectName>TaurusTLS_UT</SanitizedProjectName>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <DCC_Define>MEMLEAK_CHECK;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android)'!=''">
         <DCC_UsePackage>fmx;DbxCommonDriver;bindengine;IndyIPCommon;emsclient;FireDACCommonDriver;IndyProtocols;dbxcds;IndyIPClient;FmxTeeUI;bindcompfmx;ibmonitor;FireDACSqliteDriver;DbxClientDriver;soapmidas;fmxFireDAC;dbexpress;inet;DataSnapCommon;fmxase;dbrtl;FireDACDBXDriver;CustomIPTransport;DBXInterBaseDriver;IndySystem;ibxbindings;bindcomp;FireDACCommon;emsserverresource;inetstn;IndyCore;RESTBackendComponents;bindcompdbx;rtl;RESTComponents;DBXSqliteDriver;dsnapxml;DataSnapClient;DataSnapProviderClient;IndyIPServer;DataSnapFireDAC;emsclientfiredac;FireDAC;FireDACDSDriver;xmlrtl;tethering;ibxpress;dsnap;CloudService;FMXTee;DataSnapNativeClient;soaprtl;soapserver;FireDACIBDriver;$(DCC_UsePackage)</DCC_UsePackage>
@@ -150,6 +157,12 @@
         <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
         <DCC_DebugInformation>0</DCC_DebugInformation>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Linux64)'!=''">
+        <Debugger_UseLauncher>true</Debugger_UseLauncher>
+        <Debugger_RunParams>-exit:Pause</Debugger_RunParams>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
+    </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
@@ -206,6 +219,12 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
+                <DeployFile LocalName="Linux64\Release\TaurusTLS.UT" Configuration="Release" Class="ProjectOutput">
+                    <Platform Name="Linux64">
+                        <RemoteName>TaurusTLS_UT</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
                 <DeployFile LocalName="Win32\Debug\TaurusTLS.UT.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>TaurusTLS.UT.exe</RemoteName>
@@ -215,12 +234,6 @@
                 <DeployFile LocalName="Win64\Debug\TaurusTLS.UT.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win64">
                         <RemoteName>TaurusTLS.UT.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="Win64\Debug\TaurusTLS.UT.rsm" Configuration="Debug" Class="DebugSymbols">
-                    <Platform Name="Win64">
-                        <RemoteName>TaurusTLS.UT.rsm</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>


### PR DESCRIPTION
* Fixed: inlining for `Random methods` returning `Extended type` random value
* Corrected: Constructor and Destructor inherited calls
* Corrected: `RandomExtended` internal function to eliminate Math unit usage
* Minor correction in `Taurus.UT.Random` unit-tests

Unit compiled with `Debug` and `Product` build configs for `Win32`, `Win64` and `Linux64` targets.  