### PR TITLE
Updated: TaurusTLSHeaders_bio function declaration and unit-tests

### DIFF
--- a/Source/TaurusTLSHeaders_bio.pas
+++ b/Source/TaurusTLSHeaders_bio.pas
@@ -500,9 +500,17 @@ var
   BIO_do_accept: function (b: PBIO): TIdC_LONG; cdecl = nil; {removed 1.0.0}
   BIO_do_handshake: function (b: PBIO): TIdC_LONG; cdecl = nil; {removed 1.0.0}
 
-  BIO_get_mem_data: function (b: PBIO; pp: PIdAnsiChar) : TIdC_INT; cdecl = nil; {removed 1.0.0}
+  // WAS DECLARED AS:
+  // original declaration of parameter pp was invalid.
+  // correct declaration should be "pp: PIdAnsiChar" according to OpenSSL documentation}
+  // BIO_get_mem_data: function (b: PBIO; pp: PIdAnsiChar) : TIdC_INT; cdecl = nil; {removed 1.0.0}
+  BIO_get_mem_data: function (b: PBIO; var pp: Pointer) : TIdC_INT; cdecl = nil; {removed 1.0.0}
   BIO_set_mem_buf: function (b: PBIO; bm: PIdAnsiChar; c: TIdC_INT): TIdC_INT; cdecl = nil; {removed 1.0.0}
-  BIO_get_mem_ptr: function (b: PBIO; pp: PIdAnsiChar): TIdC_INT; cdecl = nil; {removed 1.0.0}
+  // WAS DECLARED AS:
+  // original declaration of parameter pp was invalid.
+  // correct declaration should be "pp: PIdAnsiChar" according to OpenSSL documentation}
+  // BIO_get_mem_data: function (b: PBIO; pp: PIdAnsiChar) : TIdC_INT; cdecl = nil; {removed 1.0.0}
+  BIO_get_mem_ptr: function (b: PBIO; var pp: Pointer): TIdC_INT; cdecl = nil; {removed 1.0.0}
   BIO_set_mem_eof_return: function (b: PBIO; v: TIdC_INT): TIdC_INT; cdecl = nil; {removed 1.0.0}
 
   BIO_get_new_index: function : TIdC_INT; cdecl = nil; {introduced 1.1.0}
@@ -1278,9 +1286,13 @@ function BIO_should_retry(b: PBIO): TIdC_INT; {removed 1.0.0}
 function BIO_do_connect(b: PBIO): TIdC_LONG; {removed 1.0.0}
 function BIO_do_accept(b: PBIO): TIdC_LONG; {removed 1.0.0}
 function BIO_do_handshake(b: PBIO): TIdC_LONG; {removed 1.0.0}
-function BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT; {removed 1.0.0}
+// WAS DECLARED AS:
+// function BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT; {removed 1.0.0}
+function BIO_get_mem_data(b: PBIO; var pp: Pointer) : TIdC_INT; {removed 1.0.0}
 function BIO_set_mem_buf(b: PBIO; bm: PIdAnsiChar; c: TIdC_INT): TIdC_INT; {removed 1.0.0}
-function BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT; {removed 1.0.0}
+// WAS DECLARED AS:
+// function BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT; {removed 1.0.0}
+function BIO_get_mem_ptr(b: PBIO; var pp: Pointer): TIdC_INT; {removed 1.0.0}
 function BIO_set_mem_eof_return(b: PBIO; v: TIdC_INT): TIdC_INT; {removed 1.0.0}
 {$ENDIF}
 
@@ -1840,10 +1852,12 @@ begin
   Result := BIO_ctrl(b, BIO_C_DO_STATE_MACHINE, 0, nil);
 end;
 
+// WAS DECLARED AS:
+// function  _BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT; cdecl;
 //# define BIO_get_mem_data(b,pp)  BIO_ctrl(b,BIO_CTRL_INFO,0,(char (pp))
-function  _BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT; cdecl;
+function  _BIO_get_mem_data(b: PBIO; var pp: Pointer) : TIdC_INT; cdecl;
 begin
-  Result := BIO_ctrl(b, BIO_CTRL_INFO, 0, pp);
+  Result := BIO_ctrl(b, BIO_CTRL_INFO, 0, @pp);
 end;
 
 //# define BIO_set_mem_buf(b,bm,c) BIO_ctrl(b,BIO_C_SET_BUF_MEM,c,(char (bm))
@@ -1852,10 +1866,12 @@ begin
   Result := BIO_ctrl(b, BIO_C_SET_BUF_MEM, c, bm);
 end;
 
+// WAS DECLARED AS:
+// function  _BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT; cdecl;
 //# define BIO_get_mem_ptr(b,pp)   BIO_ctrl(b,BIO_C_GET_BUF_MEM_PTR,0,(char (pp))
-function  _BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT; cdecl;
+function  _BIO_get_mem_ptr(b: PBIO; var pp: Pointer): TIdC_INT; cdecl;
 begin
-  Result := BIO_ctrl(b, BIO_C_GET_BUF_MEM_PTR, 0, pp);
+  Result := BIO_ctrl(b, BIO_C_GET_BUF_MEM_PTR, 0, @pp);
 end;
 
 //# define BIO_set_mem_eof_return(b,v) BIO_ctrl(b,BIO_C_SET_BUF_MEM_EOF_RETURN,v,0)
@@ -1956,32 +1972,36 @@ end;
 
  
 
-function  ERR_BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT; 
+// WAS DECLARED AS:
+// function  ERR_BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT;
+function  ERR_BIO_get_mem_data(b: PBIO; var pp: Pointer) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(BIO_get_mem_data_procname);
 end;
 
- 
-function  ERR_BIO_set_mem_buf(b: PBIO; bm: PIdAnsiChar; c: TIdC_INT): TIdC_INT; 
+
+function  ERR_BIO_set_mem_buf(b: PBIO; bm: PIdAnsiChar; c: TIdC_INT): TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(BIO_set_mem_buf_procname);
 end;
 
- 
-function  ERR_BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT; 
+
+// WAS DECLARED AS:
+// function  ERR_BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT;
+function  ERR_BIO_get_mem_ptr(b: PBIO; var pp: Pointer): TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(BIO_get_mem_ptr_procname);
 end;
 
- 
-function  ERR_BIO_set_mem_eof_return(b: PBIO; v: TIdC_INT): TIdC_INT; 
+
+function  ERR_BIO_set_mem_eof_return(b: PBIO; v: TIdC_INT): TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(BIO_set_mem_eof_return_procname);
 end;
 
- 
 
-function  ERR_BIO_get_new_index: TIdC_INT; 
+
+function  ERR_BIO_get_new_index: TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(BIO_get_new_index_procname);
 end;
@@ -7604,8 +7624,10 @@ begin
   Result := BIO_ctrl(b, BIO_C_DO_STATE_MACHINE, 0, nil);
 end;
 
+// WAS DECLARED AS:
+//function BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT;
 //# define BIO_get_mem_data(b,pp)  BIO_ctrl(b,BIO_CTRL_INFO,0,(char (pp))
-function BIO_get_mem_data(b: PBIO; pp: PIdAnsiChar) : TIdC_INT;
+function BIO_get_mem_data(b: PBIO; var pp: Pointer) : TIdC_INT;
 begin
   Result := BIO_ctrl(b, BIO_CTRL_INFO, 0, pp);
 end;
@@ -7616,8 +7638,10 @@ begin
   Result := BIO_ctrl(b, BIO_C_SET_BUF_MEM, c, bm);
 end;
 
+// WAS DECLARED AS:
+// function BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT;
 //# define BIO_get_mem_ptr(b,pp)   BIO_ctrl(b,BIO_C_GET_BUF_MEM_PTR,0,(char (pp))
-function BIO_get_mem_ptr(b: PBIO; pp: PIdAnsiChar): TIdC_INT;
+function BIO_get_mem_ptr(b: PBIO; var pp: Pointer): TIdC_INT;
 begin
   Result := BIO_ctrl(b, BIO_C_GET_BUF_MEM_PTR, 0, pp);
 end;

--- a/Source/TaurusTLS_X509.pas
+++ b/Source/TaurusTLS_X509.pas
@@ -1218,7 +1218,7 @@ begin
       try
         if X509_print_ex(LMem, FX509, XN_FLAG_COMPAT, X509_FLAG_COMPAT) = 1 then
         begin
-          LLen := BIO_get_mem_data(LMem, @LBufPtr);
+          LLen := BIO_get_mem_data(LMem, LBufPtr);
           if (LLen > 0) and (LBufPtr <> nil) then
           begin
             {$ifndef fpc}

--- a/Tests/TaurusTLS.UT.Headers.Bio.pas
+++ b/Tests/TaurusTLS.UT.Headers.Bio.pas
@@ -1,0 +1,294 @@
+unit TaurusTLS.UT.Headers.Bio;
+
+interface
+
+uses
+  DUnitX.TestFramework, TaurusTLS.UT.TestClasses,
+  IdGlobal, IdCTypes, TaurusTLSHeaders_types, TaurusTLSHeaders_bio;
+
+type
+  [TestFixture]
+  [Category('BIO')]
+  TBioReadWriteFixture = class(TOsslBaseFixture)
+  protected type
+    TBIO_ReadProc = reference to function(const ABio: PBio;
+      var AData; AChunkLen: TIdC_SIZET): TIdC_SIZET;
+    TBIO_WriteProc = reference to function(const ABio: PBio;
+      const AData; AChunkLen: TIdC_SIZET): TIdC_SIZET;
+  protected
+    class function GetRandomStr(ALen: TIdC_SIZET):RawByteString; static; inline;
+    procedure Do_BIO_read(const AValue: RawByteString; AChunkLen: TIdC_SIZET;
+      ABioProc: TBIO_ReadProc);
+    procedure Do_BIO_write(const AValue: RawByteString; AChunkLen: TIdC_SIZET;
+      ABioProc: TBIO_WriteProc);
+  public
+    [TestCase('AValue=''$$$$$$$$$$$$$$$$''', '$$$$$$$$$$$$$$$$')]
+    procedure Test_BIO_new_mem_buf(const AValue: RawByteString);
+    [TestCase('AValue=''$'',AChunkLen=3', '$, 3')]
+    [TestCase('AValue=''$$$$$$$$$$$$$$$$'',AChunkLen=3',
+      '$$$$$$$$$$$$$$$$, 3')]
+    [TestCase('AValue=''0123456789'',AChunkLen=2', '0123456789,2')]
+    procedure Test_BIO_read(const AValue: RawByteString; AChunkLen: TIdC_SIZET);
+    [TestCase('AValue=''$$$$$$$$$$$$$$$$'',ChnkLen=3',
+      '$$$$$$$$$$$$$$$$, 3')]
+    [TestCase('Value=''0123456789'',AChunkLen=2', '0123456789,2')]
+    procedure Test_BIO_read_ex(const AValue: RawByteString; AChunkLen: TIdC_SIZET);
+    [TestCase('ALength=4096,AChunkLen=256', '4096,256')]
+    [TestCase('ALength=8177,AChunkLen=513', '8177,513')]
+    procedure Test_Random_BIO_read(ALength: NativeUInt; AChunkLen: TIdC_SIZET);
+    [TestCase('ALength=4096,AChunkLen=256', '4096,256')]
+    [TestCase('ALength=8177,AChunkLen=513', '8177,513')]
+    procedure Test_Random_BIO_read_ex(ALength: NativeUInt; AChunkLen: TIdC_SIZET);
+    [TestCase('AValue=''$'',AChunkLen=3', '$, 3')]
+    [TestCase('AValue=''$$$$$$$$$$$$$$$$'',AChunkLen=3',
+      '$$$$$$$$$$$$$$$$, 3')]
+    [TestCase('AValue=''0123456789'',AChunkLen=2', '0123456789,2')]
+    procedure Test_BIO_write(const AValue: RawByteString; AChunkLen: TIdC_SIZET);
+    [TestCase('AValue=''$$$$$$$$$$$$$$$$'',ChnkLen=3',
+      '$$$$$$$$$$$$$$$$, 3')]
+    procedure Test_BIO_write_ex(const AValue: RawByteString; AChunkLen: TIdC_SIZET);
+    [TestCase('ALength=4096,AChunkLen=256', '4096,256')]
+    [TestCase('ALength=8177,AChunkLen=513', '8177,513')]
+    procedure Test_Random_BIO_write(ALength: NativeUInt; AChunkLen: TIdC_SIZET);
+    [TestCase('ALength=4096,AChunkLen=256', '4096,256')]
+    [TestCase('ALength=8177,AChunkLen=513', '8177,513')]
+    procedure Test_Random_BIO_write_ex(ALength: NativeUInt; AChunkLen: TIdC_SIZET);
+  end;
+
+implementation
+
+uses
+  System.SysUtils, System.Hash, TaurusTLSExceptionHandlers;
+
+{ TBioReadWriteDixture }
+
+class function TBioReadWriteFixture.GetRandomStr(ALen: TIdC_SIZET): RawByteString;
+begin
+  Result:=THash.GetRandomString(ALen);
+end;
+
+procedure TBioReadWriteFixture.Do_BIO_read(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET; ABioProc: TBIO_ReadProc);
+var
+  lBio: PBIO;
+  lLen: TIdC_INT;
+  lPos: TIdC_INT;
+  lRemainLen, lTestLen: TIdC_SIZET;
+  lReadLen: TIdC_SIZET;
+  lData, lTest: RawByteString;
+
+begin
+  lBio:=nil;
+  Assert.AreNotEqual<TIdC_SIZET>(0, AChunkLen, 'AChunkLen = 0');
+  lLen:=Length(AValue);
+  Assert.AreNotEqual<TIdC_SIZET>(0, lLen, 'Lenght(AValue) = 0');
+  try
+    lBio:=BIO_new_mem_buf(AValue[1], lLen);
+    Assert.IsNotNull(lBio, 'lBio is ''nil''');
+    lPos:=1;
+    lRemainLen:=lLen;
+    repeat
+      if AChunkLen > lLen then
+        AChunkLen:=lLen;
+      lTestLen:=lRemainLen;
+      if lTestLen > AChunkLen then
+        lTestLen:=AChunkLen;
+
+      SetLength(lData, AChunkLen);
+      lReadLen:=ABioProc(lBio, lData[1], AChunkLen);
+      Assert.AreEqual<TIdC_SIZET>(lTestLen, lReadLen, 'BIO_read');
+      SetLength(lData, lReadLen);
+      lTest:=Copy(AValue, lPos, lTestLen);
+      Assert.AreEqual(lTest, lData, '''lTest'' and ''lData'' are not equal');
+
+      Inc(lPos, lReadLen);
+      Assert.IsTrue(lPos <= lLen+1, 'Read outside the boundary: lPos > lLen');
+      Dec(lRemainLen, lReadLen);
+    until lRemainLen < 1;
+    // Force to read outside the buffer size
+    SetLength(lData, AChunkLen);
+    lReadLen:=ABioProc(lBio, lData[1], AChunkLen);
+    Assert.AreEqual<TIdC_SIZET>(0, lReadLen, 'Read outside the boundary: lReadLen');
+  finally
+    BIO_free(lBio);
+  end;
+end;
+
+procedure TBioReadWriteFixture.Do_BIO_write(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET; ABioProc: TBIO_WriteProc);
+var
+  lBio: PBIO;
+  lLen: TIdC_INT;
+  lPos: TIdC_INT;
+  lTestLen: TIdC_SIZET;
+  lWriteLen, lBufLen: TIdC_SIZET;
+  lBufPtr: Pointer;
+
+begin
+  lBio:=nil;
+  Assert.AreNotEqual<TIdC_SIZET>(0, AChunkLen, 'AChunkLen = 0');
+  lLen:=Length(AValue);
+  Assert.AreNotEqual<TIdC_SIZET>(0, lLen, 'Lenght(AValue) = 0');
+  try
+//    lBio:=BIO_new_mem_buf(AValue, lLen);
+    lBio:=BIO_new(BIO_s_mem());
+    Assert.IsNotNull(lBio, 'lBio is ''nil''');
+    lPos:=0;
+    repeat
+      lTestLen:=lLen-lPos;
+      if lTestLen > AChunkLen then
+        lTestLen:=AChunkLen;
+
+      lWriteLen:=ABioProc(lBio, AValue[lPos+1], lTestLen);
+      Assert.AreEqual<TIdC_SIZET>(lTestLen, lWriteLen, 'BIO_write');
+      lBufLen:=BIO_get_mem_data(lBio, lBufPtr);
+      Inc(lPos, lWriteLen);
+      Assert.IsTrue(lPos <= lBufLen,
+        'Write Buffer shoreter than current position (lPos > lBufLen)');
+      Assert.IsTrue(CompareMem(@AValue[1], lBufPtr, lPos),
+        'Source and Write Buffer are not equal.)');
+    until lPos >= lLen;
+  finally
+    BIO_free(lBio);
+  end;
+end;
+
+procedure TBioReadWriteFixture.Test_BIO_new_mem_buf(const AValue: RawByteString);
+var
+  lBio: PBIO;
+  lLen, lDataLen: TIdC_INT;
+  lData: Pointer;
+
+begin
+  lBio:=nil;
+  lLen:=Length(AValue);
+  Assert.AreNotEqual<TIdC_INT>(0, lLen, 'Lenght(AValue) = 0');
+  try
+    lBio:=BIO_new_mem_buf(AValue[1], lLen);
+    Assert.IsNotNull(lBio, 'lBio is ''nil''');
+    lDataLen:=BIO_get_mem_data(lBio, lData);
+    Assert.AreEqual<TIdC_INT>(lLen, lDataLen, 'BIO_get_mem_data(lBio, lData) <> 1');
+    Assert.AreEqual<pointer>(@AValue[1], lData, '@AValue and lData are not equal');
+  finally
+    BIO_free(lBio);
+  end;
+end;
+
+procedure TBioReadWriteFixture.Test_BIO_read(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_read(AValue, AChunkLen,
+    function(const ABio: PBio;
+      var AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    begin
+      Result:=BIO_read(ABio, AData, AChunkLen);
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_Random_BIO_read(ALength: NativeUInt;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_read(GetRandomStr(ALength), AChunkLen,
+    function(const ABio: PBio;
+      var AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    begin
+      Result:=BIO_read(ABio, AData, AChunkLen);
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_BIO_read_ex(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_read(AValue, AChunkLen,
+    function(const ABio: PBio;
+      var AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    begin
+      BIO_read_ex(ABio, AData, AChunkLen, Result);
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_Random_BIO_read_ex(ALength: NativeUInt;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_read(GetRandomStr(ALength), AChunkLen,
+    function(const ABio: PBio;
+      var AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    begin
+      BIO_read_ex(ABio, AData, AChunkLen, Result);
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_BIO_write(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_write(AValue, AChunkLen,
+    function(const ABio: PBio;
+      const AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    var
+      lResult: TIdC_SSIZET;
+    begin
+      lResult:=BIO_write(ABio, AData, AChunkLen);
+      if lResult < 0 then
+        ETaurusTLSAPICryptoError.RaiseException
+      else
+        Result:=lResult;
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_BIO_write_ex(const AValue: RawByteString;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_write(AValue, AChunkLen,
+    function(const ABio: PBio;
+      const AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    var
+      lResult: TIdC_SSIZET;
+    begin
+      lResult:=BIO_write_ex(ABio, AData, AChunkLen, Result);
+      Assert.AreEqual<TIdC_SSIZET>(1, lResult, 'BIO_write_ex');
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_Random_BIO_write(ALength: NativeUInt;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_write(GetRandomStr(ALength), AChunkLen,
+    function(const ABio: PBio;
+      const AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    var
+      lResult: TIdC_SSIZET;
+    begin
+      lResult:=BIO_write(ABio, AData, AChunkLen);
+      if lResult < 0 then
+        ETaurusTLSAPICryptoError.RaiseException
+      else
+        Result:=lResult;
+    end
+  );
+end;
+
+procedure TBioReadWriteFixture.Test_Random_BIO_write_ex(ALength: NativeUInt;
+  AChunkLen: TIdC_SIZET);
+begin
+  Do_BIO_write(GetRandomStr(ALength), AChunkLen,
+    function(const ABio: PBio;
+      const AData; AChunkLen: TIdC_SIZET): TIdC_SIZET
+    var
+      lResult: TIdC_SSIZET;
+    begin
+      lResult:=BIO_write_ex(ABio, AData, AChunkLen, Result);
+      Assert.AreEqual<TIdC_SSIZET>(1, lResult, 'BIO_write_ex');
+    end
+  );
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TBioReadWriteFixture);
+
+end.

--- a/Tests/TaurusTLS.UT.dpr
+++ b/Tests/TaurusTLS.UT.dpr
@@ -38,7 +38,8 @@ uses
   TaurusTLS.UT.Utils in 'TaurusTLS.UT.Utils.pas',
   TaurusTLS.UT.TestClasses in 'TaurusTLS.UT.TestClasses.pas',
   TaurusTLS.UT.Dummy in 'TaurusTLS.UT.Dummy.pas',
-  TaurusTLS.UT.Random in 'TaurusTLS.UT.Random.pas';
+  TaurusTLS.UT.Random in 'TaurusTLS.UT.Random.pas',
+  TaurusTLS.UT.Headers.Bio in 'TaurusTLS.UT.Headers.Bio.pas';
 
 { keep comment here to protect the following conditional from being removed by the IDE when adding a unit }
 {$IFNDEF TESTINSIGHT}

--- a/Tests/TaurusTLS.UT.dproj
+++ b/Tests/TaurusTLS.UT.dproj
@@ -5,7 +5,7 @@
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
         <Config Condition="'$(Config)'==''">Release</Config>
-        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <Platform Condition="'$(Platform)'==''">Win64</Platform>
         <TargetedPlatforms>131</TargetedPlatforms>
         <AppType>Console</AppType>
         <MainSource>TaurusTLS.UT.dpr</MainSource>
@@ -66,6 +66,12 @@
         <Cfg_1>true</Cfg_1>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win64)'!=''">
+        <Cfg_1_Win64>true</Cfg_1_Win64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
         <Cfg_2>true</Cfg_2>
         <CfgParent>Base</CfgParent>
@@ -101,7 +107,7 @@
         <UsingDelphiRTL>true</UsingDelphiRTL>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>$(DUnitX);$(FastMM5);$(TaurusTLSDev);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>$(DUnitX);$(FastMM5);$(TaurusTLSDev);$(INDYDEV_BASE)\Lib\Core;$(INDYDEV_BASE)\Lib\Protocols;$(INDYDEV_BASE)\Lib\System;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <SanitizedProjectName>TaurusTLS_UT</SanitizedProjectName>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
@@ -137,7 +143,7 @@
         <DCC_UsePackage>vclwinx;DataSnapServer;fmx;vclie;DbxCommonDriver;bindengine;VCLRESTComponents;FireDACCommonODBC;DBXMSSQLDriver;IndyIPCommon;emsclient;FireDACCommonDriver;appanalytics;IndyProtocols;vclx;dbxcds;vcledge;IndyIPClient;bindcompvclwinx;FmxTeeUI;bindcompfmx;DBXFirebirdDriver;inetdb;ibmonitor;FireDACSqliteDriver;DbxClientDriver;FireDACASADriver;Tee;soapmidas;vclactnband;TeeUI;fmxFireDAC;dbexpress;FireDACInfxDriver;DBXMySQLDriver;VclSmp;inet;DataSnapCommon;vcltouch;fmxase;DBXOdbcDriver;dbrtl;FireDACDBXDriver;FireDACOracleDriver;fmxdae;TeeDB;FireDACMSAccDriver;CustomIPTransport;FireDACMSSQLDriver;DataSnapIndy10ServerTransport;DataSnapConnectors;vcldsnap;DBXInterBaseDriver;FireDACMongoDBDriver;IndySystem;FireDACTDataDriver;Skia.Package.VCL;vcldb;ibxbindings;vclFireDAC;bindcomp;FireDACCommon;DataSnapServerMidas;FireDACODBCDriver;emsserverresource;inetstn;IndyCore;RESTBackendComponents;bindcompdbx;rtl;FireDACMySQLDriver;FireDACADSDriver;RESTComponents;DBXSqliteDriver;vcl;dsnapxml;adortl;dsnapcon;DataSnapClient;DataSnapProviderClient;IndyIPServer;TaurusTLS_RT;DBXSybaseASEDriver;DBXDb2Driver;vclimg;DataSnapFireDAC;emsclientfiredac;FireDACPgDriver;FireDAC;FireDACDSDriver;inetdbxpress;xmlrtl;tethering;ibxpress;bindcompvcl;dsnap;CloudService;DBXSybaseASADriver;DBXOracleDriver;FireDACDb2Driver;DBXInformixDriver;vclib;fmxobj;bindcompvclsmp;FMXTee;DataSnapNativeClient;DatasnapConnectorsFreePascal;soaprtl;soapserver;FireDACIBDriver;$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\1.1\Win64</Debugger_RunParams>
+        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\3.5\Win64 --include:BIO</Debugger_RunParams>
         <Manifest_File>(None)</Manifest_File>
         <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
     </PropertyGroup>
@@ -161,7 +167,10 @@
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>(None)</Manifest_File>
         <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
-        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\3.5\Win32</Debugger_RunParams>
+        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\1.1\Win32 --include:BIO</Debugger_RunParams>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
+        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\1.1\Win64 --include:BIO</Debugger_RunParams>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
@@ -176,10 +185,12 @@
         <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\3.5\Win32</Debugger_RunParams>
+        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\1.1\Win32 --include:BIO</Debugger_RunParams>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win64)'!=''">
-        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\3.5\Win64</Debugger_RunParams>
+        <Debugger_RunParams>-exit:Pause  -osp:..\..\..\..\OpenSSL\3.5\Win64 </Debugger_RunParams>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">
@@ -189,6 +200,7 @@
         <DCCReference Include="TaurusTLS.UT.TestClasses.pas"/>
         <DCCReference Include="TaurusTLS.UT.Dummy.pas"/>
         <DCCReference Include="TaurusTLS.UT.Random.pas"/>
+        <DCCReference Include="TaurusTLS.UT.Headers.Bio.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -243,7 +255,19 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
+                <DeployFile LocalName="TaurusTLS.UT.Headers.Bio.inc" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win32">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
                 <DeployFile LocalName="Win32\Debug\TaurusTLS.UT.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>TaurusTLS.UT.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win32\Release\TaurusTLS.UT.exe" Configuration="Release" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>TaurusTLS.UT.exe</RemoteName>
                         <Overwrite>true</Overwrite>


### PR DESCRIPTION
* TaurusTLSHeaders_bio: parameters in some functions updated to use with native Pascal syntax
* TaurusTLS.UT.Headers.Bio: some of modified functions covered by unit tests
* TTaurusTLSX509.GetDisplayInfo method updated to use ne syntax of BIO_get_mem_data function.

Please review these changes carefully as they may introduce regressions.