### PR TITLE
Fixed: Memory leak in TTaurusTLS_CustomEncryptor.Destroy.

### DIFF
--- a/Source/TaurusTLS_Encryptors.pas
+++ b/Source/TaurusTLS_Encryptors.pas
@@ -616,6 +616,7 @@ end;
 
 destructor TTaurusTLS_CustomEncryptor.Destroy;
 begin
+  EVP_CIPHER_CTX_free(FCtx);
   FreeAndNil(FCipher);
   inherited;
 end;


### PR DESCRIPTION
Major memory leak is resolved.
==9468== LEAK SUMMARY:
==9468==    definitely lost: 11,952 bytes in 63 blocks
==9468==    indirectly lost: 27,400 bytes in 101 blocks
==9468==      possibly lost: 0 bytes in 0 blocks
==9468==    still reachable: 620,825 bytes in 511 blocks
==9468==                       of which reachable via heuristic:
==9468==                         newarray           : 395,040 bytes in 34 blocks
==9468==         suppressed: 0 bytes in 0 blocks

However small leaks in the OpenSSL malloc  are still exists. I need help to resolve them.

==9473== 2,144 (1,280 direct, 864 indirect) bytes in 5 blocks are definitely lost in loss record 151 of 174
==9473==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==9473==    by 0x7F547C4: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F29503: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F2A976: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F2AF4B: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F504A8: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F501BF: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F5FF96: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F50337: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F506D8: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F2B6DC: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==    by 0x7F2BAE3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.3)
==9473==
==9473== LEAK SUMMARY:
==9473==    definitely lost: 1,280 bytes in 5 blocks
==9473==    indirectly lost: 864 bytes in 19 blocks
==9473==      possibly lost: 0 bytes in 0 blocks
==9473==    still reachable: 620,825 bytes in 511 blocks
==9473==                       of which reachable via heuristic:
==9473==                         newarray           : 395,040 bytes in 34 blocks
==9473==         suppressed: 0 bytes in 0 blocks