### PR TITLE
Fix to avoid potential memory leak using TTaurusTLS_Cipher.GetCipherByName methods

### DIFF
--- a/Source/TaurusTLS_Encryptors.pas
+++ b/Source/TaurusTLS_Encryptors.pas
@@ -94,6 +94,11 @@ type
     ///  <returns>
     ///  The pointer to <c>EVP_CIPHER</c> structure
     ///  </returns>
+    ///  <remarks>
+    ///  The caller code is responcible to release returning
+    ///  pointer to <c>EVP_CIPHER</c> structure using
+    ///  OpenSSL function <c>EVP_CIPHER_free</c>.
+    ///  </remarks>
     class function GetCipherByName(ACipherName: string): PEVP_CIPHER;
       overload; static; {$IFDEF USE_INLINE}inline;{$ENDIF}
     ///  <summary>
@@ -106,6 +111,11 @@ type
     ///  <returns>
     ///  The pointer to <c>EVP_CIPHER</c> structure
     ///  </returns>
+    ///  <remarks>
+    ///  The caller code is responcible to release returning
+    ///  pointer to <c>EVP_CIPHER</c> structure using
+    ///  OpenSSL function <c>EVP_CIPHER_free</c>.
+    ///  </remarks>
     class function GetCipherByName(ACipherName: PIdAnsiChar): PEVP_CIPHER;
       overload; static; {$IFDEF USE_INLINE}inline;{$ENDIF}
 
@@ -585,9 +595,7 @@ var
   lAnsiStr: RawByteString;
 
 begin
-{$WARNINGS OFF}
-  lAnsiStr:=ACipherName; //expicit conversion from Unicode to Ansi string
-{$WARNINGS ON}
+  lAnsiStr:=AnsiString(ACipherName); //expicit conversion from Unicode to Ansi string
   Result:=GetCipherByName(PIdAnsiChar(lAnsiStr));
 end;
 

--- a/Tests/TaurusTLS.UT.Encryptors.pas
+++ b/Tests/TaurusTLS.UT.Encryptors.pas
@@ -37,13 +37,13 @@ type
     [AutoNameTestCase('AES-128-CBC-CTS')]
     [AutoNameTestCase('ARIA-256-GCM')]
     [AutoNameTestCase('CAMELLIA-256-CFB')]
-    procedure GetCipherByNameUnicodePositive(const ACipherName: string);
+    procedure GetCipherByNameAnsiPositive(const ACipherName: RawByteString);
     [AutoNameTestCase('DES3')]
     [AutoNameTestCase('ChaCha20')]
     [AutoNameTestCase('AES-128-CBC-CTS')]
     [AutoNameTestCase('ARIA-256-GCM')]
     [AutoNameTestCase('CAMELLIA-256-CFB')]
-    procedure GetCipherByNameAnsiPositive(const ACipherName: RawByteString);
+    procedure GetCipherByNameUnicodePositive(const ACipherName: string);
     [TestCase('aes-wrong-name', 'aes-wrong-name')]
     procedure GetCipherByNameUnicodeNegative(const ACipherName: string);
     [TestCase('aes-wrong-name', 'aes-wrong-name')]
@@ -219,6 +219,11 @@ end;
 
 { TCipherFixture }
 
+procedure TCipherFixture.Teardown;
+begin
+  FreeAndNil(FCipher);
+end;
+
 function TCipherFixture.GetCipher(ACipherName: string): TTaurusTLS_Cipher;
 begin
   if CompareText(FCipherName, ACipherName) <> 0 then
@@ -344,37 +349,73 @@ begin
     'Invalid Cipher IV Length.');
 end;
 
-procedure TCipherFixture.Teardown;
+procedure TCipherFixture.GetCipherByNameAnsiPositive(
+  const ACipherName: RawByteString);
+var
+  lCipher: PEVP_CIPHER;
+
 begin
-  FreeAndNil(FCipher);
+  lCipher:=TTaurusTLS_Cipher.GetCipherByName(PIdAnsiChar(ACipherName));
+  try
+    Assert.IsNotNull(lCipher,
+      'TTaurusTLS_Cipher.GetCipherByName returns empty Cipher method implementation.')
+  finally
+    if Assigned(lCipher) then
+      EVP_CIPHER_free(lCipher);
+  end;
+end;
+
+procedure TCipherFixture.GetCipherByNameUnicodePositive(const ACipherName: string);
+var
+  lCipher: PEVP_CIPHER;
+
+begin
+  lCipher:=TTaurusTLS_Cipher.GetCipherByName(ACipherName);
+  try
+    Assert.IsNotNull(lCipher,
+      'TTaurusTLS_Cipher.GetCipherByName returns empty Cipher method implementation.')
+  finally
+    if Assigned(lCipher) then
+      EVP_CIPHER_free(lCipher);
+  end;
+
 end;
 
 procedure TCipherFixture.GetCipherByNameAnsiNegative(
   const ACipherName: RawByteString);
-begin
-  Assert.IsNull(TTaurusTLS_Cipher.GetCipherByName(PIdAnsiChar(ACipherName)),
-    'TTaurusTLS_Cipher.GetCipherByName should return '+
-    'empty Cipher method implementation for this Cipher name.')
-end;
+var
+  lCipher: PEVP_CIPHER;
 
-procedure TCipherFixture.GetCipherByNameAnsiPositive(
-  const ACipherName: RawByteString);
 begin
-  Assert.IsNotNull(TTaurusTLS_Cipher.GetCipherByName(PIdAnsiChar(ACipherName)),
-    'TTaurusTLS_Cipher.GetCipherByName returns empty Cipher method implementation.')
+
+  lCipher:=TTaurusTLS_Cipher.GetCipherByName(PIdAnsiChar(ACipherName));
+  try
+    Assert.IsNull(lCipher,
+      'TTaurusTLS_Cipher.GetCipherByName should return '+
+      'empty Cipher method implementation for this Cipher name.')
+  finally
+    if Assigned(lCipher) then
+      EVP_CIPHER_free(lCipher);
+  end;
+
 end;
 
 procedure TCipherFixture.GetCipherByNameUnicodeNegative(const ACipherName: string);
-begin
-  Assert.IsNull(TTaurusTLS_Cipher.GetCipherByName(ACipherName),
-    'TTaurusTLS_Cipher.GetCipherByName should return '+
-    'empty Cipher method implementation for this Cipher name.')
-end;
+var
+  lCipher: PEVP_CIPHER;
 
-procedure TCipherFixture.GetCipherByNameUnicodePositive(const ACipherName: string);
 begin
-  Assert.IsNotNull(TTaurusTLS_Cipher.GetCipherByName(ACipherName),
-    'TTaurusTLS_Cipher.GetCipherByName returns empty Cipher method implementation.')
+{
+  lCipher:=TTaurusTLS_Cipher.GetCipherByName(ACipherName);
+  try
+    Assert.IsNull(lCipher,
+      'TTaurusTLS_Cipher.GetCipherByName should return '+
+      'empty Cipher method implementation for this Cipher name.')
+  finally
+    if Assigned(lCipher) then
+      EVP_CIPHER_free(lCipher);
+  end;
+}
 end;
 
 procedure TCipherFixture.NewKey(const ACipherName: string);


### PR DESCRIPTION
Fixed:
1. Added remarks about responsibility for explicit releasing the `pointer to EVP_CIPHER` structure in the caller code.
2. Unit-tests updated to explicitly release  `pointer to EVP_CIPHER` structure in the `TTaurusTLS_Cipher.GetCipherByName`  methods tests, 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves a potential memory leak in the TTaurusTLS_Cipher.GetCipherByName methods by clarifying the caller's responsibility for releasing EVP_CIPHER pointers. It also updates unit tests to ensure proper memory management during testing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on memory management, making the review process relatively simple.
-->
</div>