### PR TITLE
Cleaning Tests/TaurusTLS.UT.TestClasses.pas from innecesary Log() functions.

### DIFF
--- a/Tests/TaurusTLS.UT.TestClasses.pas
+++ b/Tests/TaurusTLS.UT.TestClasses.pas
@@ -208,7 +208,6 @@ var
 {$ENDIF}
 
 begin
-  Log('----- SetupFixture start -----');
 {$IFDEF MSWINDOWS}
   {$IFDEF MEMLEAK_DETAILS}
   TFastMMDebugLog.DebugModeActive:=True;
@@ -216,33 +215,24 @@ begin
   lDebugActive:=TFastMMDebugLog.DebugModeActive; // To enforce linker add the TFastMMDebugLog class
   {$ENDIF MEMLEAK_DETAILS}
 {$ENDIF}
-  Log('TFastMMDebugLog.DebugModeActive = '+TFastMMDebugLog.DebugModeActive.ToString(True));
   try
-    Log('Loading OpenSSL');
     SetOssLibLoaded(TOsslLoader.Load);
-    Log(Format('Flags after loading = %x', [Cardinal(FFlags)]));
     CheckAllFailures;
   except
-    Log('Exception raised.');
     SetGlobalFail(True);
     raise
   end;
-  Log('----- SetupFixture ends  -----');
 end;
 
 procedure TOsslBaseFixture.TearDownFixture;
 begin
-  Log('----- TearDownFixture start -----');
-  Log('OssLibLoaded = '+OssLibLoaded.ToString(True));
   if OssLibLoaded then
   try
     TOsslLoader.Unload;
   except
-    Log('Exception raised.');
     SetGlobalFail(True);
     raise;
   end;
-  Log('----- TearDownFixture ends  -----');
 end;
 
 initialization


### PR DESCRIPTION
This specially updated debug file was committed by mistake. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request cleans up the test file Tests/TaurusTLS.UT.TestClasses.pas by removing unnecessary Log() function calls, enhancing readability and maintainability without changing functionality. It addresses a previous mistake of committing unnecessary debug logs.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>