### PR TITLE
Fix in d2i_AutoPrivateKey_ex declaration for static linking model

### DIFF
--- a/Source/TaurusTLSHeaders_evp.pas
+++ b/Source/TaurusTLSHeaders_evp.pas
@@ -2346,7 +2346,7 @@ var
   function d2i_PrivateKey(type_: TIdC_INT; a: PEVP_PKEY; const pp: PPByte; _length: TIdC_LONG): PEVP_PKEY cdecl; external CLibCrypto;
   function d2i_AutoPrivateKey(a: PPEVP_PKEY; const pp: PPByte; _length: TIdC_LONG): PEVP_PKEY cdecl; external CLibCrypto;
   function d2i_AutoPrivateKey_ex(a: PPEVP_PKEY; const pp: PPByte; _length: TIdC_LONG;
-    libctx : POSSL_LIB_CTX; propq : PIdAnsiChar): PEVP_PKEY; cdecl = nil;
+    libctx : POSSL_LIB_CTX; propq : PIdAnsiChar): PEVP_PKEY; cdecl;  external CLibCrypto;
   function i2d_PrivateKey(a: PEVP_PKEY; pp: PPByte): TIdC_INT cdecl; external CLibCrypto;
   function i2d_KeyParams_bio(pb : PBIO; const pkey : PEVP_PKEY) : TIdC_INT;  cdecl; external CLibCrypto;
   function d2i_KeyParams_bio(type_ : TIdC_INT; var a : PEVP_PKEY; in_ : PBIO) : PEVP_PKEY;  cdecl; external CLibCrypto;


### PR DESCRIPTION
This fix resolves package compilation fail for Mobile platforms 
(where OPENSSL_STATIC_LINK_MODEL is defined) 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves a compilation issue for mobile platforms by correcting the function declaration of d2i_AutoPrivateKey_ex, ensuring compatibility with the OPENSSL_STATIC_LINK_MODEL. This fix is essential for successful package compilation on these platforms.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>