### PR TITLE
Small fix in code in and unit test added.

### DIFF
--- a/Source/TaurusTLS_SSLContainersHelpers.pas
+++ b/Source/TaurusTLS_SSLContainersHelpers.pas
@@ -884,7 +884,7 @@ begin
   if Result > 0 then
     Result:=AStream.Read(ABytes, ACount);
   if Result < ACount then
-    SetLength(ABytes, AAddTrailingNulls);
+    SetLength(ABytes, Result+AAddTrailingNulls);
 end;
 
 class function TBytesFactory.Create(const AStream: TStream;
@@ -902,6 +902,7 @@ begin
   lPos:=AStream.Position;
   AStream.WipeMemoryData(lPos,
     CreateFromStream(AStream, Result, ACount, AAddTrailingNulls));
+
 end;
 
 end.


### PR DESCRIPTION
- Fix in TBytesFactory.CreateFromStream: incorrect returning array size calculation in some conditions.
- Unit tests for TBytesFactory.CreateAndWipeMemBuf 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes an issue with array size calculation in the CreateFromStream method of the TBytesFactory class. It also adds comprehensive unit tests for the CreateAndWipeMemBuf method, enhancing the overall reliability and robustness of the component.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>