### PR TITLE
Fix: Typos in TBytesFactory.CreateFromStream returning type

### DIFF
--- a/Source/TaurusTLS_SSLContainersHelpers.pas
+++ b/Source/TaurusTLS_SSLContainersHelpers.pas
@@ -171,7 +171,7 @@ type
 
     class function CreateFromStream(const AStream: TStream;
       out ABytes: TBytes; ACount: NativeUInt;
-      AAddTrailingNulls: TTrailingNulls = 0): NativeInt;
+      AAddTrailingNulls: TTrailingNulls = 0): NativeUInt;
       overload; static;
 
     ///  <summary>
@@ -869,17 +869,17 @@ end;
 
 class function TBytesFactory.CreateFromStream(const AStream: TStream;
   out ABytes: TBytes; ACount: NativeUInt;
-  AAddTrailingNulls: TTrailingNulls = 0): NativeInt;
+  AAddTrailingNulls: TTrailingNulls = 0): NativeUInt;
 begin
   if (ACount <= 0) and (not Assigned(AStream)) then
     ACount:=AStream.Size;
   Result:=ACount;
 {$IFDEF FPC}
-  {$WARN 5093 off}
+  {$WARN 5092 off}
 {$ENDIF}
   SetLength(ABytes, ACount+AAddTrailingNulls);
 {$IFDEF FPC}
-  {$WARN 5093 on}
+  {$WARN 5092 on}
 {$ENDIF}
   if Result > 0 then
     Result:=AStream.Read(ABytes, ACount);


### PR DESCRIPTION
Fix 2 warnings:
* Returnig type of TBytesFactory.CreateFromStream
* {$WARN 5093 off} in TBytesFactory.CreateAsUTF8AndWipe 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves two warnings in the TBytesFactory.CreateFromStream method by correcting the return type from NativeInt to NativeUInt and updating the warning suppression directive to the correct number.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>