### PR TITLE
Enabling compile to use strict types check.

### DIFF
--- a/Source/TaurusTLSHeaders_asn1.pas
+++ b/Source/TaurusTLSHeaders_asn1.pas
@@ -876,7 +876,7 @@ var
 
   ASN1_d2i_bio: function(xnew: pxnew; d2i: pd2i_of_void; in_: PBIO; x: PPointer): Pointer; cdecl = nil;
   ASN1_item_d2i_bio: function (const it: PASN1_ITEM; in_: PBIO; x: Pointer): Pointer; cdecl = nil;
-  ASN1_i2d_bio: function (i2d: Pi2d_of_void; out_: PBIO; x: PByte): TIdC_INT; cdecl = nil;
+  ASN1_i2d_bio: function (i2d: i2d_of_void; out_: PBIO; x: PByte): TIdC_INT; cdecl = nil;
 
   //#  define ASN1_i2d_bio_of(type,i2d,out,x) \
   //    (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), \
@@ -1207,7 +1207,7 @@ var
   //                          CHECKED_PPTR_OF(type, x)))
 
   function ASN1_item_d2i_bio(const it: PASN1_ITEM; in_: PBIO; x: Pointer): Pointer cdecl; external CLibCrypto;
-  function ASN1_i2d_bio(i2d: Pi2d_of_void; out_: PBIO; x: PByte): TIdC_INT cdecl; external CLibCrypto;
+  function ASN1_i2d_bio(i2d: i2d_of_void; out_: PBIO; x: PByte): TIdC_INT cdecl; external CLibCrypto;
 
   //#  define ASN1_i2d_bio_of(type,i2d,out,x) \
   //    (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), \
@@ -2666,7 +2666,7 @@ begin
 end;
 
 
-function  ERR_ASN1_i2d_bio(i2d: Pi2d_of_void; out_: PBIO; x: PByte): TIdC_INT; 
+function  ERR_ASN1_i2d_bio(i2d: i2d_of_void; out_: PBIO; x: PByte): TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(ASN1_i2d_bio_procname);
 end;

--- a/Source/TaurusTLSHeaders_core.pas
+++ b/Source/TaurusTLSHeaders_core.pas
@@ -129,7 +129,9 @@ uses
           return_size : TIdC_SSIZET;
         end;
 
-      OSSL_PARAM = ossl_param_st;
+      OSSL_PARAM        = ossl_param_st;
+      POSSL_PARAM       = ^OSSL_PARAM;
+      POSSL_PARAM_ARRAY = POSSL_PARAM; // declaration of "array of OSSL_PARAM"
 
     { Currently supported OSSL_PARAM data types  }
     {
@@ -256,10 +258,10 @@ type
      * libcrypto may use the OSSL_PARAM array to create arguments for an
      * application callback it knows about.
       }
-    OSSL_CALLBACK = function(params: array of OSSL_PARAM; arg: pointer): TIdC_INT cdecl;
+    OSSL_CALLBACK = function(params: POSSL_PARAM_ARRAY; arg: pointer): TIdC_INT cdecl;
 
-    OSSL_INOUT_CALLBACK = function(in_params: array of OSSL_PARAM;
-                                  out_params: array of OSSL_PARAM; arg: pointer): TIdC_INT cdecl;
+    OSSL_INOUT_CALLBACK = function(in_params: POSSL_PARAM_ARRAY;
+                                  out_params: POSSL_PARAM_ARRAY; arg: pointer): TIdC_INT cdecl;
 
     {
      * Passphrase callback function signature
@@ -269,7 +271,7 @@ type
       }
     OSSL_PASSPHRASE_CALLBACK = function(pass: PIdAnsiChar; pass_size: TIdC_SSIZET;
                                        pass_len: PIdC_SSIZET;
-                                       params: array of OSSL_PARAM; arg: pointer): TIdC_INT cdecl;
+                                       params: POSSL_PARAM_ARRAY; arg: pointer): TIdC_INT cdecl;
 
 
 implementation

--- a/Source/TaurusTLSHeaders_err.pas
+++ b/Source/TaurusTLSHeaders_err.pas
@@ -435,7 +435,8 @@ procedure  _ERR_put_error(lib: TIdC_INT; func: TIdC_INT; reason: TIdC_INT; file_
 begin
   ERR_new;
   ERR_set_debug(file_,line, '');
-  ERR_set_error(lib,reason,'',[]);
+//  ERR_set_error(lib,reason,'',[]);
+    ERR_set_error(lib,reason,'');
 end;
 
 procedure  _X509err(const f,r : TIdC_INT); cdecl;

--- a/Source/TaurusTLSHeaders_err.pas
+++ b/Source/TaurusTLSHeaders_err.pas
@@ -237,7 +237,8 @@ var
 
   ERR_new: procedure ; cdecl = nil; {introduced 3.0.0}
   ERR_set_debug: procedure (const file_: PIdAnsiChar; line: TIdC_INT; const func: PIdAnsiChar); cdecl = nil;  {introduced 3.0.0}
-  ERR_set_error: procedure (lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const); cdecl = nil; {introduced 3.0.0}
+//  ERR_set_error: procedure (lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const); cdecl = nil; {introduced 3.0.0}
+  ERR_set_error: procedure (lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar); cdecl varargs = nil; {introduced 3.0.0}
 
 
   ERR_set_error_data: procedure (data: PIdAnsiChar; flags: TIdC_INT); cdecl = nil;
@@ -290,8 +291,8 @@ var
 
   procedure ERR_new cdecl; external CLibCrypto; {introduced 3.0.0}
   procedure ERR_set_debug(const file_: PIdAnsiChar; line: TIdC_INT; const func: PIdAnsiChar) cdecl; external CLibCrypto;  {introduced 3.0.0}
-  procedure ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const) cdecl; external CLibCrypto; {introduced 3.0.0}
-
+//  procedure ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const) cdecl; external CLibCrypto; {introduced 3.0.0}
+  procedure ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar) cdecl; varargs; external CLibCrypto; {introduced 3.0.0}
 
   procedure ERR_set_error_data(data: PIdAnsiChar; flags: TIdC_INT) cdecl; external CLibCrypto;
 
@@ -472,7 +473,8 @@ begin
 end;
 
   {introduced 3.0.0}
-procedure  ERR_ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const);
+//procedure  ERR_ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar; args: array of const);
+procedure  ERR_ERR_set_error(lib: TIdC_INT; reason: TIdC_INT; fmt: PIdAnsiChar) cdecl;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(ERR_set_error_procname);
 end;

--- a/Source/TaurusTLSHeaders_evp.pas
+++ b/Source/TaurusTLSHeaders_evp.pas
@@ -35,7 +35,8 @@ uses
   {$IFDEF OPENSSL_STATIC_LINK_MODEL}
   TaurusTLSConsts,
   {$ENDIF}
-  TaurusTLSHeaders_types;
+  TaurusTLSHeaders_types,
+  TaurusTLSHeaders_core;
 
 const
   EVP_MAX_MD_SIZE = 64; // longest known is SHA512
@@ -1820,15 +1821,15 @@ var
   EVP_MAC_get0_description : function(const mac : PEVP_MAC) : PIdAnsiChar; cdecl = nil;
   EVP_MAC_get0_provider : function(const mac :PEVP_MAC) : POSSL_PROVIDER; cdecl = nil;
 
-  EVP_MAC_get_params : function(mac : PEVP_MAC; params : array of OSSL_PARAM) : TIdC_INT; cdecl = nil;
+  EVP_MAC_get_params : function(mac : PEVP_MAC; params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl = nil;
 
   EVP_MAC_CTX_new : function (mac : PEVP_MAC) : PEVP_MAC_CTX; cdecl = nil; {introduced 3.0.0}
   EVP_MAC_CTX_free : procedure (ctx : PEVP_MAC_CTX ); cdecl = nil;  {introduced 3.0.0}
 
   EVP_MAC_CTX_dup : function(const  src : PEVP_MAC_CTX) : PEVP_MAC_CTX; cdecl = nil;
   EVP_MAC_CTX_get0_mac : function(ctx : PEVP_MAC_CTX) : PEVP_MAC; cdecl = nil;
-  EVP_MAC_CTX_get_params : function(ctx : PEVP_MAC_CTX; params : array of OSSL_PARAM) : TIdC_INT; cdecl = nil;
-  EVP_MAC_CTX_set_params : function(ctx : PEVP_MAC_CTX; const  params : array of OSSL_PARAM) : TIdC_INT; cdecl = nil;
+  EVP_MAC_CTX_get_params : function(ctx : PEVP_MAC_CTX; params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl = nil;
+  EVP_MAC_CTX_set_params : function(ctx : PEVP_MAC_CTX; const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl = nil;
 
   EVP_MAC_CTX_get_mac_size : function (ctx : PEVP_MAC_CTX) : TIdC_SIZET; cdecl = nil;
   EVP_MAC_CTX_get_block_size : function (ctx : PEVP_MAC_CTX) : TIdC_SIZET; cdecl = nil;
@@ -1838,8 +1839,8 @@ var
     const data : PIdAnsiChar; datalen : TIdC_SIZET; _out : PIdAnsiChar;
     outsize : TIdC_SIZET;  var outlen : TIdC_SIZET) : PIdAnsiChar; cdecl = nil;
   EVP_MAC_init: function(ctx : PEVP_MAC_CTX; const key : PIdAnsiChar; keylen : TIdC_SIZET;
-     const  params : array of OSSL_PARAM) : TIdC_INT; cdecl = nil;
-  EVP_MAC_init_SKEY : function(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : array of OSSL_PARAM) : TIdC_INT; cdecl = nil;
+     const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl = nil;
+  EVP_MAC_init_SKEY : function(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl = nil;
   EVP_MAC_update : function(ctx : PEVP_MAC_CTX; const data : PIdAnsiChar;
     datalen : TIdC_SIZET) : TIdC_INT; cdecl = nil;
   EVP_MAC_final : function(ctx : PEVP_MAC_CTX;
@@ -2612,15 +2613,15 @@ function EVP_PKEY_assign_POLY1305(pkey: PEVP_PKEY; polykey: Pointer): TIdC_INT; 
   function EVP_MAC_get0_description(const mac : PEVP_MAC) : PIdAnsiChar; cdecl; external CLibCrypto;
   function EVP_MAC_get0_provider(const mac :PEVP_MAC) : POSSL_PROVIDER; cdecl; external CLibCrypto;
 
-  function EVP_MAC_get_params(mac : PEVP_MAC; params : array of OSSL_PARAM) : TIdC_INT; cdecl; external CLibCrypto;
+  function EVP_MAC_get_params(mac : PEVP_MAC; params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl; external CLibCrypto;
 
   function EVP_MAC_CTX_new(mac : PEVP_MAC) : PEVP_MAC_CTX cdecl; external CLibCrypto;  {introduced 3.0.0}
   procedure EVP_MAC_CTX_free (ctx : PEVP_MAC_CTX ) cdecl; external CLibCrypto;   {introduced 3.0.0}
 
   function EVP_MAC_CTX_dup(const  src : PEVP_MAC_CTX) : PEVP_MAC_CTX; cdecl; external CLibCrypto;
   function EVP_MAC_CTX_get0_mac(ctx : PEVP_MAC_CTX) : PEVP_MAC; cdecl; external CLibCrypto;
-  function EVP_MAC_CTX_get_params(ctx : PEVP_MAC_CTX; params : array of OSSL_PARAM) : TIdC_INT; cdecl; external CLibCrypto;
-  function EVP_MAC_CTX_set_params(ctx : PEVP_MAC_CTX; const  params : array of OSSL_PARAM) : TIdC_INT; cdecl; external CLibCrypto;
+  function EVP_MAC_CTX_get_params(ctx : PEVP_MAC_CTX; params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl; external CLibCrypto;
+  function EVP_MAC_CTX_set_params(ctx : PEVP_MAC_CTX; const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl; external CLibCrypto;
 
   function EVP_MAC_CTX_get_mac_size(ctx : PEVP_MAC_CTX) : TIdC_SIZET; cdecl; external CLibCrypto;
   function EVP_MAC_CTX_get_block_size(ctx : PEVP_MAC_CTX) : TIdC_SIZET; cdecl; external CLibCrypto;
@@ -2631,8 +2632,8 @@ function EVP_PKEY_assign_POLY1305(pkey: PEVP_PKEY; polykey: Pointer): TIdC_INT; 
     _out : PIdAnsiChar; outsize : TIdC_SIZET;
     var outlen : TIdC_SIZET) : PIdAnsiChar; cdecl; external CLibCrypto;
   function EVP_MAC_init(ctx : PEVP_MAC_CTX; const key : PIdAnsiChar; keylen : TIdC_SIZET;
-                 const  params : array of OSSL_PARAM) : TIdC_INT; cdecl; external CLibCrypto;
-  function EVP_MAC_init_SKEY(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : array of OSSL_PARAM) : TIdC_INT; cdecl; external CLibCrypto;
+                 const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl; external CLibCrypto;
+  function EVP_MAC_init_SKEY(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : POSSL_PARAM_ARRAY) : TIdC_INT; cdecl; external CLibCrypto;
 
   function EVP_MAC_update(ctx : PEVP_MAC_CTX; const data : PIdAnsiChar;
     datalen : TIdC_SIZET) : TIdC_INT; cdecl; external CLibCrypto;
@@ -7442,7 +7443,7 @@ begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_get0_provider_procname);
 end;
 
-function ERR_EVP_MAC_get_params(mac : PEVP_MAC; params : array of OSSL_PARAM) : TIdC_INT;
+function ERR_EVP_MAC_get_params(mac : PEVP_MAC; params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_get_params_procname);
 end;
@@ -7467,12 +7468,12 @@ begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_CTX_get0_mac_procname);
 end;
 
-  function ERR_EVP_MAC_CTX_get_params(ctx : PEVP_MAC_CTX; params : array of OSSL_PARAM) : TIdC_INT;
+  function ERR_EVP_MAC_CTX_get_params(ctx : PEVP_MAC_CTX; params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_CTX_get_params_procname);
 end;
 
-  function ERR_EVP_MAC_CTX_set_params(ctx : PEVP_MAC_CTX; const  params : array of OSSL_PARAM) : TIdC_INT;
+  function ERR_EVP_MAC_CTX_set_params(ctx : PEVP_MAC_CTX; const  params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_CTX_set_params_procname);
 end;
@@ -7488,12 +7489,12 @@ begin
 end;
 
 function ERR_EVP_MAC_init(ctx : PEVP_MAC_CTX; const key : PIdAnsiChar; keylen : TIdC_SIZET;
-                 const  params : array of OSSL_PARAM) : TIdC_INT;
+                 const  params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_init_procname);
 end;
 
-function ERR_EVP_MAC_init_SKEY(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : array of OSSL_PARAM) : TIdC_INT;
+function ERR_EVP_MAC_init_SKEY(ctx : PEVP_MAC_CTX;  skey : PEVP_SKEY; const  params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
    ETaurusTLSAPIFunctionNotPresent.RaiseException(EVP_MAC_init_SKEY_procname);
 end;

--- a/Source/TaurusTLSHeaders_store.pas
+++ b/Source/TaurusTLSHeaders_store.pas
@@ -29,7 +29,8 @@ uses
   {$IFDEF OPENSSL_STATIC_LINK_MODEL}
   TaurusTLSConsts,
   {$ENDIF}
-  TaurusTLSHeaders_types;
+  TaurusTLSHeaders_types,
+  TaurusTLSHeaders_core;
 
 type
   POSSL_STORE_CTX  = type Pointer;
@@ -84,13 +85,13 @@ var
 
   OSSL_STORE_open_ex : function(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                    const ui_method : PUI_METHOD; ui_data : Pointer;
-                   const params : Array of OSSL_PARAM;
+                   const params : POSSL_PARAM_ARRAY;
                    post_process : OSSL_STORE_post_process_info_fn;
                    post_process_data : Pointer) : POSSL_STORE_CTX cdecl = nil;
   OSSL_STORE_load : function(ctx : POSSL_STORE_CTX) : POSSL_STORE_INFO cdecl = nil;
   OSSL_STORE_delete : function(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                       const ui_method : PUI_METHOD; ui_data : Pointer;
-                      const  params : array of OSSL_PARAM) : TIdC_INT cdecl = nil;
+                      const  params : POSSL_PARAM_ARRAY) : TIdC_INT cdecl = nil;
   OSSL_STORE_eof : function(ctx : POSSL_STORE_CTX) : TIdC_INT cdecl = nil;
   OSSL_STORE_error: function(ctx : POSSL_STORE_CTX) : TIdC_INT cdecl = nil;
   OSSL_STORE_close : function(ctx : POSSL_STORE_CTX) : TIdC_INT cdecl = nil;
@@ -98,7 +99,7 @@ var
   OSSL_STORE_attach : function(bio : PBIO; const scheme : PIdAnsiChar;
                              libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                              const ui_method : PUI_METHOD; ui_data : Pointer;
-                             const  params : array of OSSL_PARAM;
+                             const  params : POSSL_PARAM_ARRAY;
                              post_process : OSSL_STORE_post_process_info_fn;
                              post_process_data : Pointer) : POSSL_STORE_CTX cdecl = nil;
 
@@ -207,14 +208,14 @@ var
 
   function OSSL_STORE_open_ex(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                    const ui_method : PUI_METHOD; ui_data : Pointer;
-                   const params : Array of OSSL_PARAM;
+                   const params : POSSL_PARAM_ARRAY;
                    post_process : OSSL_STORE_post_process_info_fn;
                    post_process_data : Pointer) : POSSL_STORE_CTX cdecl; external CLibCrypto;
   function OSSL_STORE_load(ctx : POSSL_STORE_CTX) : POSSL_STORE_INFO cdecl; external CLibCrypto;
 
   function OSSL_STORE_delete(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                       const ui_method : PUI_METHOD; ui_data : Pointer;
-                      const  params : array of OSSL_PARAM) : TIdC_INT cdecl; external CLibCrypto;
+                      const  params : POSSL_PARAM_ARRAY) : TIdC_INT cdecl; external CLibCrypto;
   function OSSL_STORE_eof(ctx : POSSL_STORE_CTX) : TIdC_INT cdecl; external CLibCrypto;
   function OSSL_STORE_error(ctx : POSSL_STORE_CTX) : TIdC_INT  cdecl; external CLibCrypto;
   function OSSL_STORE_close(ctx : POSSL_STORE_CTX) : TIdC_INT cdecl; external CLibCrypto;
@@ -222,7 +223,7 @@ var
   function OSSL_STORE_attach(bio : PBIO; const scheme : PIdAnsiChar;
                              libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                              const ui_method : PUI_METHOD; ui_data : Pointer;
-                             const  params : array of OSSL_PARAM;
+                             const  params : POSSL_PARAM_ARRAY;
                              post_process : OSSL_STORE_post_process_info_fn;
                              post_process_data : Pointer) : POSSL_STORE_CTX cdecl; external CLibCrypto;
 
@@ -463,7 +464,7 @@ end;
 
 function ERR_OSSL_STORE_open_ex(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                    const ui_method : PUI_METHOD; ui_data : Pointer;
-                   const params : Array of OSSL_PARAM;
+                   const params : POSSL_PARAM_ARRAY;
                    post_process : OSSL_STORE_post_process_info_fn;
                    post_process_data : Pointer) : POSSL_STORE_CTX;
 begin
@@ -482,7 +483,7 @@ end;
 
 function ERR_OSSL_STORE_delete(const uri : PIdAnsiChar; libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                       const ui_method : PUI_METHOD; ui_data : Pointer;
-                      const  params : array of OSSL_PARAM) : TIdC_INT;
+                      const  params : POSSL_PARAM_ARRAY) : TIdC_INT;
 begin
   ETaurusTLSAPIFunctionNotPresent.RaiseException(OSSL_STORE_delete_procname);
 end;
@@ -500,7 +501,7 @@ end;
 function ERR_OSSL_STORE_attach(bio : PBIO; const scheme : PIdAnsiChar;
                              libctx : POSSL_LIB_CTX; const propq : PIdAnsiChar;
                              const ui_method : PUI_METHOD; ui_data : Pointer;
-                             const  params : array of OSSL_PARAM;
+                             const  params : POSSL_PARAM_ARRAY;
                              post_process : OSSL_STORE_post_process_info_fn;
                              post_process_data : Pointer) : POSSL_STORE_CTX;
 begin

--- a/Source/TaurusTLSHeaders_types.pas
+++ b/Source/TaurusTLSHeaders_types.pas
@@ -651,6 +651,7 @@ type
 
   OSSL_PARAM = record end;
   POSSL_PARAM = ^OSSL_PARAM;
+  POSSL_PARAM_ARRAY = POSSL_PARAM; // declaration of "array of OSSL_PARAM"
 
   pem_password_cb = function(buf: PIdAnsiChar; size: TIdC_INT; rwflag: TIdC_INT; userdata: Pointer): TIdC_INT; cdecl;
 

--- a/Source/TaurusTLSHeaders_types.pas
+++ b/Source/TaurusTLSHeaders_types.pas
@@ -618,11 +618,13 @@ type
   PX509_ALGOR = ^X509_ALGOR;
   PPX509_ALGOR = ^PX509_ALGOR;
 
-  i2d_of_void = type Pointer;
-  Pi2d_of_void = ^i2d_of_void;
+//  i2d_of_void = type Pointer;
+//  Pi2d_of_void = ^i2d_of_void;
+  i2d_of_void = function(const data: Pointer; pp: PPIdAnsiChar): Pointer;
 
-  d2i_of_void = type Pointer;
-  Pd2i_of_void = ^d2i_of_void;
+//  d2i_of_void = type Pointer;
+//  Pd2i_of_void = ^d2i_of_void;
+  d2i_of_void = function(data: PPointer; pp: PPIdAnsiChar; length: TIdC_Long): pointer;
 
   {OSSL_LIB_CTX is defined in types.h from 3.0.0 onwards}
   //  typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;

--- a/Source/TaurusTLSHeaders_types.pas
+++ b/Source/TaurusTLSHeaders_types.pas
@@ -620,11 +620,12 @@ type
 
 //  i2d_of_void = type Pointer;
 //  Pi2d_of_void = ^i2d_of_void;
-  i2d_of_void = function(const data: Pointer; pp: PPIdAnsiChar): Pointer;
+  i2d_of_void = function(const data: Pointer; pp: PPIdAnsiChar): Pointer; cdecl;
 
 //  d2i_of_void = type Pointer;
 //  Pd2i_of_void = ^d2i_of_void;
   d2i_of_void = function(data: PPointer; pp: PPIdAnsiChar; length: TIdC_Long): pointer;
+    cdecl;
 
   {OSSL_LIB_CTX is defined in types.h from 3.0.0 onwards}
   //  typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
@@ -649,9 +650,9 @@ type
   OSSL_DECODER_CTX  = record end;
   POSSL_DECODER_CTX = ^OSSL_DECODER_CTX;
 
-  OSSL_PARAM = record end;
-  POSSL_PARAM = ^OSSL_PARAM;
-  POSSL_PARAM_ARRAY = POSSL_PARAM; // declaration of "array of OSSL_PARAM"
+//  OSSL_PARAM = record end;
+//  POSSL_PARAM = ^OSSL_PARAM;
+//  POSSL_PARAM_ARRAY = POSSL_PARAM; // declaration of "array of OSSL_PARAM"
 
   pem_password_cb = function(buf: PIdAnsiChar; size: TIdC_INT; rwflag: TIdC_INT; userdata: Pointer): TIdC_INT; cdecl;
 

--- a/Source/TaurusTLSHeaders_types.pas
+++ b/Source/TaurusTLSHeaders_types.pas
@@ -159,172 +159,252 @@ type
   end;
 
   // moved from asn1
-  PASN1_VALUE = type Pointer;
-  PPASN1_VALUE = ^PASN1_VALUE;
+  ASN1_VALUE    = record end;
+  PASN1_VALUE   = ^ASN1_VALUE;
+  PPASN1_VALUE  = ^PASN1_VALUE;
 
   // moved from e_os2
   ossl_ssize_t = type {$IFDEF WIN64}TIdC_INT64{$ELSE}TIdC_INT{$ENDIF};
 
-  PASN1_OBJECT = type Pointer;
+  ASN1_OBJECT   = record end;
+  PASN1_OBJECT  = ^ASN1_OBJECT;
   PPASN1_OBJECT = ^PASN1_OBJECT;
 
-  ASN1_INTEGER = type asn1_string_st;
-  PASN1_INTEGER = ^ASN1_INTEGER;
-  PPASN1_INTEGER = ^PASN1_INTEGER;
+  ASN1_INTEGER    = type asn1_string_st;
+  PASN1_INTEGER   = ^ASN1_INTEGER;
+  PPASN1_INTEGER  = ^PASN1_INTEGER;
 
-  ASN1_ENUMERATED = type asn1_string_st;
-  PASN1_ENUMERATED = ^ASN1_ENUMERATED;
+  ASN1_ENUMERATED   = type asn1_string_st;
+  PASN1_ENUMERATED  = ^ASN1_ENUMERATED;
 
-  ASN1_BIT_STRING = type asn1_string_st;
-  PASN1_BIT_STRING = ^ASN1_BIT_STRING;
+  ASN1_BIT_STRING   = type asn1_string_st;
+  PASN1_BIT_STRING  = ^ASN1_BIT_STRING;
   PPASN1_BIT_STRING = ^PASN1_BIT_STRING;
 
-  ASN1_OCTET_STRING = type asn1_string_st;
-  PASN1_OCTET_STRING = ^ASN1_OCTET_STRING;
+  ASN1_OCTET_STRING   = type asn1_string_st;
+  PASN1_OCTET_STRING  = ^ASN1_OCTET_STRING;
   PPASN1_OCTET_STRING = ^PASN1_OCTET_STRING;
 
-  ASN1_PRINTABLESTRING = type asn1_string_st;
+  ASN1_PRINTABLESTRING  = type asn1_string_st;
   PASN1_PRINTABLESTRING = ^ASN1_PRINTABLESTRING;
 
-  ASN1_T61STRING = type asn1_string_st;
+  ASN1_T61STRING  = type asn1_string_st;
   PASN1_T61STRING = ^ASN1_T61STRING;
 
-  ASN1_IA5STRING = type asn1_string_st;
+  ASN1_IA5STRING  = type asn1_string_st;
   PASN1_IA5STRING = ^ASN1_IA5STRING;
 
-  ASN1_GENERALSTRING = type asn1_string_st;
+  ASN1_GENERALSTRING  = type asn1_string_st;
   PASN1_GENERALSTRING = ^ASN1_GENERALSTRING;
 
-  ASN1_UNIVERSALSTRING = type asn1_string_st;
+  ASN1_UNIVERSALSTRING  = type asn1_string_st;
   PASN1_UNIVERSALSTRING = ^ASN1_UNIVERSALSTRING;
 
-  ASN1_BMPSTRING = type asn1_string_st;
+  ASN1_BMPSTRING  = type asn1_string_st;
   PASN1_BMPSTRING = ^ASN1_BMPSTRING;
 
-  ASN1_UTCTIME = type asn1_string_st;
-  PASN1_UTCTIME = ^ASN1_UTCTIME;
-  PPASN1_UTCTIME = ^PASN1_UTCTIME;
+  ASN1_UTCTIME    = type asn1_string_st;
+  PASN1_UTCTIME   = ^ASN1_UTCTIME;
+  PPASN1_UTCTIME  = ^PASN1_UTCTIME;
 
-  ASN1_TIME = type asn1_string_st;
-  PASN1_TIME = ^ASN1_TIME;
+  ASN1_TIME   = type asn1_string_st;
+  PASN1_TIME  = ^ASN1_TIME;
   PPASN1_TIME = ^PASN1_TIME;
 
-  ASN1_GENERALIZEDTIME = type asn1_string_st;
-  PASN1_GENERALIZEDTIME = ^ASN1_GENERALIZEDTIME;
-  PPASN1_GENERALIZEDTIME = ^PASN1_GENERALIZEDTIME;
+  ASN1_GENERALIZEDTIME    = type asn1_string_st;
+  PASN1_GENERALIZEDTIME   = ^ASN1_GENERALIZEDTIME;
+  PPASN1_GENERALIZEDTIME  = ^PASN1_GENERALIZEDTIME;
 
-  ASN1_VISIBLESTRING = type asn1_string_st;
+  ASN1_VISIBLESTRING  = type asn1_string_st;
   PASN1_VISIBLESTRING = ^ASN1_VISIBLESTRING;
 
-  ASN1_UTF8STRING = type asn1_string_st;
-  PASN1_UTF8STRING = ^ASN1_UTF8STRING;
+  ASN1_UTF8STRING   = type asn1_string_st;
+  PASN1_UTF8STRING  = ^ASN1_UTF8STRING;
 
-  ASN1_STRING = type asn1_string_st;
-  PASN1_STRING = ^ASN1_STRING;
+  ASN1_STRING   = type asn1_string_st;
+  PASN1_STRING  = ^ASN1_STRING;
   PPASN1_STRING = ^PASN1_STRING;
 
-  ASN1_BOOLEAN = type TIdC_INT;
+  ASN1_BOOLEAN  = type TIdC_INT;
   PASN1_BOOLEAN = ^ASN1_BOOLEAN;
 
-  ASN1_NULL = type TIdC_INT;
-  PASN1_NULL = ^ASN1_NULL;
+  ASN1_NULL   = type TIdC_INT;
+  PASN1_NULL  = ^ASN1_NULL;
 
-  PASN1_ITEM = type Pointer;
+  ASN1_ITEM   = record end;
+  PASN1_ITEM  = type Pointer;
 
-  PASN1_PCTX = type Pointer;
+  ASN1_PCTX   = record end;
+  PASN1_PCTX = ^ASN1_PCTX;
 
-  PASN1_SCTX = type Pointer;
+  ASN1_SCTX   = record end;
+  PASN1_SCTX  = ^ASN1_SCTX;
 
-  PBIO = type Pointer;
-  PPBIO  = ^PBIO;
-  PBIGNUM = type Pointer;
+  BIO   = record end;
+  PBIO  = ^BIO;
+  PPBIO = ^PBIO;
+
+  BIGNUM    = record end;
+  PBIGNUM   = ^BIGNUM;
   PPBIGNUM  = ^PBIGNUM;
-  PBN_CTX = type Pointer;
-  PBN_BLINDING = type Pointer;
-  PBN_MONT_CTX = type Pointer;
-  PBN_RECP_CTX = type Pointer;
-  PBN_GENCB = type Pointer;
 
-  PBUF_MEM = Pointer;
+  BN_CTX  = record end;
+  PBN_CTX = ^BN_CTX;
 
-  PEVP_CIPHER = type Pointer;
-  PPEVP_CIPHER = ^PEVP_CIPHER;
-  PEVP_CIPHER_CTX = type Pointer;
-  PEVP_MD = type Pointer;
-  PPEVP_MD = ^PEVP_MD;
-  PEVP_MD_CTX = type Pointer;
+  BN_BLINDING   = record end;
+  PBN_BLINDING  = ^BN_BLINDING;
 
-  PEVP_PKEY = type Pointer;
-  PPEVP_PKEY = ^PEVP_PKEY;
-  PEVP_SKEY = type Pointer;
-  PPEVP_SKEY = ^PEVP_SKEY;
-  PEVP_PKEY_ASN1_METHOD = type Pointer;
-  PPEVP_PKEY_ASN1_METHOD = ^PEVP_PKEY_ASN1_METHOD;
+  BN_MONT_CTX   = record end;
+  PBN_MONT_CTX  = ^BN_MONT_CTX;
 
-  PEVP_PKEY_METHOD = type Pointer;
+  BN_RECP_CTX   = record end;
+  PBN_RECP_CTX  = ^BN_RECP_CTX;
+
+  BN_GENCB    = record end;
+  PBN_GENCB   = ^BN_GENCB;
+
+  BUF_MEM   = record end;
+  PBUF_MEM  = ^BUF_MEM;
+
+  EVP_CIPHER    = record end;
+  PEVP_CIPHER   = ^EVP_CIPHER;
+  PPEVP_CIPHER  = ^PEVP_CIPHER;
+
+  EVP_CIPHER_CTX  = record end;
+  PEVP_CIPHER_CTX = ^EVP_CIPHER_CTX;
+
+  EVP_MD    = record end;
+  PEVP_MD   = ^EVP_MD;
+  PPEVP_MD  = ^PEVP_MD;
+
+  EVP_MD_CTX  = record end;
+  PEVP_MD_CTX = ^EVP_MD_CTX;
+
+  EVP_PKEY    = record end;
+  PEVP_PKEY   = type Pointer;
+  PPEVP_PKEY  = ^PEVP_PKEY;
+
+  EVP_SKEY    = record end;
+  PEVP_SKEY   = ^EVP_SKEY;
+  PPEVP_SKEY  = ^PEVP_SKEY;
+
+  EVP_PKEY_ASN1_METHOD    = record end;
+  PEVP_PKEY_ASN1_METHOD   = ^EVP_PKEY_ASN1_METHOD;
+  PPEVP_PKEY_ASN1_METHOD  = ^PEVP_PKEY_ASN1_METHOD;
+
+  EVP_PKEY_METHOD   = record end;
+  PEVP_PKEY_METHOD  = ^EVP_PKEY_METHOD;
   PPEVP_PKEY_METHOD = ^PEVP_PKEY_METHOD;
-  PEVP_PKEY_CTX = type Pointer;
-  PPEVP_PKEY_CTX = ^PEVP_PKEY_CTX;
 
-  PEVP_ENCODE_CTX = type Pointer;
+  EVP_PKEY_CTX    = record end;
+  PEVP_PKEY_CTX   = ^EVP_PKEY_CTX;
+  PPEVP_PKEY_CTX  = ^PEVP_PKEY_CTX;
 
-  PHMAC_CTX = type Pointer;
+  EVP_ENCODE_CTX  = record end;
+  PEVP_ENCODE_CTX = ^EVP_ENCODE_CTX;
 
-  PEVP_MAC = type Pointer;
-  PEVP_MAC_CTX = type Pointer;
+  HMAC_CTX  = record end;
+  PHMAC_CTX = ^HMAC_CTX;
 
-  PDH = type Pointer;
-  PPDH = ^PDH;
+  EVP_MAC   = record end;
+  PEVP_MAC  = ^EVP_MAC;
+
+  EVP_MAC_CTX   = record end;
+  PEVP_MAC_CTX  = ^EVP_MAC_CTX;
+
+  DH    = record end;
+  PDH   = ^DH;
+  PPDH  = ^PDH;
+
   PDH_METHOD = type Pointer;
 
-  PDSA = type Pointer;
+  DSA   = record end;
+  PDSA  = ^DSA;
   PPDSA = ^PDSA;
-  PDSA_METHOD = type Pointer;
 
-  PRSA = type Pointer;
+  DSA_METHOD  = record end;
+  PDSA_METHOD = ^DSA_METHOD;
+
+  RSA   = record end;
+  PRSA  = ^RSA;
   PPRSA = ^PRSA;
-  PRSA_METHOD = type Pointer;
 
-  PEC_KEY = type Pointer;
-  PPEC_KEY = ^PEC_KEY;
-  PEC_KEY_METHOD = type Pointer;
+  RSA_METHOD  = record end;
+  PRSA_METHOD = ^RSA_METHOD;
 
-  PRAND_METHOD = type Pointer;
-  PRAND_DRBG = type Pointer;
+  EC_KEY    = record end;
+  PEC_KEY   = ^EC_KEY;
+  PPEC_KEY  = ^PEC_KEY;
 
-  PSSL_DANE = type Pointer;
-  PX509 = type Pointer;
-  PPX509 = ^PX509;
-  PStack_Of_X509 = type Pointer;
+  EC_KEY_METHOD   = record end;
+  PEC_KEY_METHOD  = ^EC_KEY_METHOD;
+
+  RAND_METHOD   = record end;
+  PRAND_METHOD  = ^RAND_METHOD;
+
+  RAND_DRBG   = record end;
+  PRAND_DRBG  = ^RAND_DRBG;
+
+  SSL_DANE  = record end;
+  PSSL_DANE = ^SSL_DANE;
+
+  X509    = record end;
+  PX509   = ^X509;
+  PPX509  = ^PX509;
+
+  Stack_Of_X509   = record end;
+  PStack_Of_X509  = ^Stack_Of_X509;
   PPStack_Of_X509 = ^PStack_Of_X509;
-  PX509_CRL = type Pointer;
-  PPX509_CRL = ^PX509_CRL;
-  PX509_CRL_METHOD = type Pointer;
-  PX509_REVOKED = type Pointer;
-  PPX509_REVOKED = ^PX509_REVOKED;
-  PX509_NAME = type Pointer;
+
+  X509_CRL    = record end;
+  PX509_CRL   = ^X509_CRL;
+  PPX509_CRL  = ^PX509_CRL;
+
+  X509_CRL_METHOD   = record end;
+  PX509_CRL_METHOD  = ^X509_CRL_METHOD;
+
+  X509_REVOKED    = record end;
+  PX509_REVOKED   = ^X509_REVOKED;
+  PPX509_REVOKED  = ^PX509_REVOKED;
+
+  X509_NAME   = record end;
+  PX509_NAME  = ^X509_NAME;
   PPX509_NAME = ^PX509_NAME;
-  PX509_PUBKEY = type Pointer;
+
+  X509_PUBKEY   = record end;
+  PX509_PUBKEY  = ^X509_PUBKEY;
   PPX509_PUBKEY = ^PX509_PUBKEY;
-  PX509_STORE = type Pointer;
-  PX509_STORE_CTX = type Pointer;
 
-  PX509_OBJECT = type Pointer;
-  PX509_LOOKUP = type Pointer;
-  PX509_LOOKUP_METHOD = type Pointer;
-  PX509_VERIFY_PARAM = type Pointer;
+  X509_STORE  = record end;
+  PX509_STORE = ^X509_STORE;
 
-  PX509_SIG_INFO = type Pointer;
+  X509_STORE_CTX  = record end;
+  PX509_STORE_CTX = ^X509_STORE_CTX;
 
-  pkcs8_priv_key_info_st = type Pointer;
-  PKCS8_PRIV_KEY_INFO = pkcs8_priv_key_info_st;
-  PPKCS8_PRIV_KEY_INFO = ^PKCS8_PRIV_KEY_INFO;
-  PPPKCS8_PRIV_KEY_INFO = ^PPKCS8_PRIV_KEY_INFO;
+  X509_OBJECT   = record end;
+  PX509_OBJECT  = ^X509_OBJECT;
+
+  X509_LOOKUP   = record end;
+  PX509_LOOKUP  = ^X509_LOOKUP;
+
+  X509_LOOKUP_METHOD  = record end;
+  PX509_LOOKUP_METHOD = ^X509_LOOKUP_METHOD;
+
+  X509_VERIFY_PARAM   = record end;
+  PX509_VERIFY_PARAM  = ^X509_VERIFY_PARAM;
+
+  X509_SIG_INFO   = record end;
+  PX509_SIG_INFO  = ^X509_SIG_INFO;
+
+  pkcs8_priv_key_info_st  = record end;
+  PKCS8_PRIV_KEY_INFO     = ^pkcs8_priv_key_info_st;
+  PPKCS8_PRIV_KEY_INFO    = ^PKCS8_PRIV_KEY_INFO;
+  PPPKCS8_PRIV_KEY_INFO   = ^PPKCS8_PRIV_KEY_INFO;
 
 // moved from x509 to prevent circular references
-  X509_REQ = type Pointer; // X509_req_st
-  PX509_REQ = ^X509_REQ;
-  PPX509_REQ = ^PX509_REQ;
+  X509_REQ    = record end; // X509_req_st
+  PX509_REQ   = ^X509_REQ;
+  PPX509_REQ  = ^PX509_REQ;
 
 // moved from x509v3 to prevent circular references
   (* Context specific info *)
@@ -338,54 +418,105 @@ type
     db: Pointer;
   (* Maybe more here *)
   end;
-  PX509V3_CTX = type Pointer;
-  PCONF = type Pointer;
-  POPENSSL_INIT_SETTINGS = type Pointer;
 
-  PUI = type Pointer;
-  PUI_METHOD = type Pointer;
+  X509V3_CTX  = record end;
+  PX509V3_CTX = ^X509V3_CTX;
 
-  PENGINE = type Pointer;
-  PPENGINE = ^PENGINE;
-  PSSL = type Pointer;
-  PSSL_CTX = type Pointer;
-  PPSSL_CTX  = ^PSSL_CTX;
+  CONF  = record end;
+  PCONF = ^CONF;
 
-  PCOMP_CTX = type Pointer;
-  PCOMP_METHOD = type Pointer;
+  OPENSSL_INIT_SETTINGS   = record end;
+  POPENSSL_INIT_SETTINGS  = ^OPENSSL_INIT_SETTINGS;
 
-  PX509_POLICY_NODE = type Pointer;
-  PX509_POLICY_LEVEL = type Pointer;
-  PX509_POLICY_TREE = type Pointer;
-  X509_POLICY_CACHE_st = type Pointer;
-  PX509_POLICY_CACHE = type Pointer;
+  UI  = record end;
+  PUI = ^UI;
 
-  AUTHORITY_KEYID_st = type Pointer;
-  AUTHORITY_KEYID = AUTHORITY_KEYID_st;
-  PAUTHORITY_KEYID = ^AUTHORITY_KEYID;
-  PDIST_POINT = type Pointer;
-  PISSUING_DIST_POINT = type Pointer;
-  PNAME_CONSTRAINTS = type Pointer;
+  UI_METHOD   = record end;
+  PUI_METHOD = ^UI_METHOD;
 
-  PCRYPTO_EX_DATA = type Pointer;
+  ENGINE    = record end;
+  PENGINE   = ^ENGINE;
+  PPENGINE  = ^PENGINE;
 
-  POCSP_REQ_CTX = type Pointer;
-  POCSP_RESPONSE = type Pointer;
-  POCSP_RESPID = type Pointer;
+  SSL   = record end;
+  PSSL  = ^SSL;
 
-  PSCT = type Pointer;
+  SSL_CTX   = record end;
+  PSSL_CTX  = ^SSL_CTX;
+  PPSSL_CTX = ^PSSL_CTX;
+
+  COMP_CTX    = record end;
+  PCOMP_CTX = ^COMP_CTX;
+
+  COMP_METHOD   = record end;
+  PCOMP_METHOD  = ^COMP_METHOD;
+
+  X509_POLICY_NODE  = record end;
+  PX509_POLICY_NODE = ^X509_POLICY_NODE;
+
+  X509_POLICY_LEVEL   = record end;
+  PX509_POLICY_LEVEL  = ^X509_POLICY_LEVEL;
+
+  X509_POLICY_TREE  = record end;
+  PX509_POLICY_TREE = ^X509_POLICY_TREE;
+
+  X509_POLICY_CACHE_st = record end;
+  PX509_POLICY_CACHE = ^X509_POLICY_CACHE_st;
+
+//  AUTHORITY_KEYID_st = type Pointer; // removed as not needed
+//  AUTHORITY_KEYID = AUTHORITY_KEYID_st; replaced with dummy record
+  AUTHORITY_KEYID   = record end;
+  PAUTHORITY_KEYID  = ^AUTHORITY_KEYID;
+
+  DIST_POINT  = record end;
+  PDIST_POINT = ^DIST_POINT;
+
+  ISSUING_DIST_POINT  = record end;
+  PISSUING_DIST_POINT = ^ISSUING_DIST_POINT;
+
+  NAME_CONSTRAINTS  = record end;
+  PNAME_CONSTRAINTS = ^NAME_CONSTRAINTS;
+
+  CRYPTO_EX_DATA  = record end;
+  PCRYPTO_EX_DATA = ^CRYPTO_EX_DATA;
+
+  OCSP_REQ_CTX  = record end;
+  POCSP_REQ_CTX = ^OCSP_REQ_CTX;
+
+  OCSP_RESPONSE   = record end;
+  POCSP_RESPONSE  = ^OCSP_RESPONSE;
+
+  OCSP_RESPID   = record end;
+  POCSP_RESPID  = ^OCSP_RESPID;
+
+  SCT   = record end;
+  PSCT  = ^SCT;
   PPSCT = ^PSCT;
-  PSCT_CTX = type Pointer;
-  PCTLOG = type Pointer;
+
+  SCT_CTX   = record end;
+  PSCT_CTX  = ^SCT_CTX;
+
+  CTLOG   = record end;
+  PCTLOG  = ^CTLOG;
   PPCTLOG = ^PCTLOG;
-  PCTLOG_STORE = type Pointer;
-  PCT_POLICY_EVAL_CTX = type Pointer;
 
-  POSSL_STORE_INFO = type Pointer;
-  POSSL_STORE_SEARCH = type Pointer;
+  CTLOG_STORE   = record end;
+  PCTLOG_STORE  = ^CTLOG_STORE;
 
-  PEVP_KDF = type Pointer;
-  PEVP_KDF_CTX = type Pointer;
+  CT_POLICY_EVAL_CTX  = record end;
+  PCT_POLICY_EVAL_CTX = ^CT_POLICY_EVAL_CTX;
+
+  OSSL_STORE_INFO   = record end;
+  POSSL_STORE_INFO  = ^OSSL_STORE_INFO;
+
+  OSSL_STORE_SEARCH   = record end;
+  POSSL_STORE_SEARCH  = ^OSSL_STORE_SEARCH;
+
+  EVP_KDF   = record end;
+  PEVP_KDF  = ^EVP_KDF;
+
+  EVP_KDF_CTX   = record end;
+  PEVP_KDF_CTX  = ^EVP_KDF_CTX;
 
 // moved from unit "asn1" to prevent circular references'
 const
@@ -495,17 +626,31 @@ type
 
   {OSSL_LIB_CTX is defined in types.h from 3.0.0 onwards}
   //  typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
-  POSSL_LIB_CTX = Pointer;
-  POSSL_ENCODER = Pointer;
-  POSSL_PROVIDER = Pointer;
-  POSSL_DECODER = Pointer;
-  POSSL_DECODER_CTX = Pointer;
-  OSSL_PARAM = record
-  end;
+  OSSL_LIB_CTX  = record end;
+  POSSL_LIB_CTX = ^OSSL_LIB_CTX;
+
+  OSSL_ALGORITHM  = record end;
+  POSSL_ALGORITHM = ^OSSL_ALGORITHM;
+
+  OSSL_ENCODER  = record end;
+  POSSL_ENCODER = ^OSSL_ENCODER;
+
+  OSSL_ENCODER_CTX  = record end;
+  POSSL_ENCODER_CTX = ^OSSL_ENCODER_CTX;
+
+  OSSL_PROVIDER   = record end;
+  POSSL_PROVIDER  = ^OSSL_PROVIDER;
+
+  OSSL_DECODER  = record end;
+  POSSL_DECODER = ^OSSL_DECODER;
+
+  OSSL_DECODER_CTX  = record end;
+  POSSL_DECODER_CTX = ^OSSL_DECODER_CTX;
+
+  OSSL_PARAM = record end;
   POSSL_PARAM = ^OSSL_PARAM;
-  POSSL_ENCODER_CTX = Pointer;
+
   pem_password_cb = function(buf: PIdAnsiChar; size: TIdC_INT; rwflag: TIdC_INT; userdata: Pointer): TIdC_INT; cdecl;
-  POSSL_ALGORITHM = Pointer;
 
 implementation
 

--- a/Source/TaurusTLS_Files.pas
+++ b/Source/TaurusTLS_Files.pas
@@ -258,7 +258,7 @@ begin
         if Ldefault_passwd_cb(@LPassword[0], MAX_SSL_PASSWORD_LENGTH, 0,
           SSL_CTX_get_default_passwd_cb_userdata(ctx)) <= 0 then
         begin
-          ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil, []);
+          ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil);
           Exit;
         end;
       end
@@ -266,7 +266,7 @@ begin
       begin
         // We could call  PEM_def_callback(), but I'm not sure how well
         // that works with console apps or some GUI's.  Fail the call.
-        ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil, []);
+        ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil);
         Exit;
       end;
       LP12 := d2i_PKCS12_bio(b, nil);
@@ -342,13 +342,13 @@ begin
         if Ldefault_passwd_callback(@LPassword[0], MAX_SSL_PASSWORD_LENGTH, 0,
           SSL_CTX_get_default_passwd_cb_userdata(ctx)) <= 0 then
         begin
-          ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil, []);
+          ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil);
           Exit;
         end;
       end
       else
       begin
-        ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil, []);
+        ERR_set_error(ERR_LIB_PEM, PEM_R_BAD_PASSWORD_READ, nil);
         Exit;
       end;
       LP12 := d2i_PKCS12_bio(Lb, nil);

--- a/Tests/TaurusTLS.UT.Headers.Bio.pas
+++ b/Tests/TaurusTLS.UT.Headers.Bio.pas
@@ -180,7 +180,8 @@ end;
 
 type
   // https://github.com/openssl/openssl/blob/bde55d421b1f49e31248c240efe50ff1f0d24141/include/openssl/buffer.h#L42
-  TBUF_MEM = record
+  PBUF_MEMM = ^TBUF_MEMM;
+  TBUF_MEMM = record
     length: TIdC_SIZET;
     data: PIdAnsiChar;
     max: TIdC_SIZET;
@@ -202,10 +203,10 @@ begin
     lBio:=BIO_new_mem_buf(AValue[1], lLen);
     Assert.IsNotNull(lBio, 'lBio is ''nil''');
     Assert.AreEqual<TIdC_INT>(1, BIO_get_mem_ptr(lBio, lRef), 'BIO_get_mem_ptr');
-    Assert.AreEqual<TIdC_INT>(lLen, TBUF_MEM(lRef^).length,
-      '@AValue[1] <> TBUF_MEM(lRef^).length');
-    Assert.AreEqual<pointer>(@AValue[1], TBUF_MEM(lRef^).data,
-      '@AValue[1] <> TBUF_MEM(lRef^).data');
+    Assert.AreEqual<TIdC_INT>(lLen, PBUF_MEMM(lRef)^.length,
+      '@AValue[1] <> PBUF_MEMM(lRef)^.length');
+    Assert.AreEqual<pointer>(@AValue[1], PBUF_MEMM(lRef)^.data,
+      '@AValue[1] <> PBUF_MEMM(lRef)^.data');
   finally
     BIO_free(lBio);
   end;


### PR DESCRIPTION
There are several commits in this PR enabling strict types check in:

- typed pointers
- procedural types 