### PR TITLE
Fix: TaurusTLS_NTLM untyped procedural var assignment

### DIFF
--- a/Source/TaurusTLS_NTLM.pas
+++ b/Source/TaurusTLS_NTLM.pas
@@ -197,10 +197,10 @@ end;
 initialization
 
 {$IFDEF GETURIHOST_SUPPORTED}
-IdFIPS.LoadNTLMLibrary := @LoadTaurusTLS;
-IdFIPS.IsNTLMFuncsAvail := @IsNTLMFuncsAvail;
-IdFIPS.NTLMGetLmChallengeResponse := @SetupLanManagerPassword;
-IdFIPS.NTLMGetNtChallengeResponse := @CreateNTPassword;
+IdFIPS.LoadNTLMLibrary := LoadTaurusTLS;
+IdFIPS.IsNTLMFuncsAvail := IsNTLMFuncsAvail;
+IdFIPS.NTLMGetLmChallengeResponse := SetupLanManagerPassword;
+IdFIPS.NTLMGetNtChallengeResponse := CreateNTPassword;
 {$ENDIF}
 
 end.


### PR DESCRIPTION
* TaurusTLSHeaders_sha. pas updated
* Some of units use untyped procedural parameters to register Load and Unload procedures. Fixed. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the TaurusTLS_NTLM unit by correcting untyped procedural variable assignments for NTLM functions. The changes ensure proper assignment of function pointers without the unnecessary use of the '@' operator, enhancing the reliability of NTLM functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>