### PR TITLE
Extend ITaurusTLS_Bytes interface with a Size property

### DIFF
--- a/Source/Extra/TaurusTLS_SSLContainers.pas
+++ b/Source/Extra/TaurusTLS_SSLContainers.pas
@@ -524,7 +524,7 @@ type
   ///  provide access to decrypted string only on time when they are needed
   ///  to pass to the <c>OpenSSL</c> functions.
   ///  </summary>
-  ITaurusTLS_PassphraseVault = interface
+  ITaurusTLS_PassphraseVault = interface(ITaurusTLS_Bytes)
   ['{43197D9D-2D60-40DD-B3D5-EE0B7504EDD3}']
     ///  <summary>
     ///  Returns instance of <see cref="ITaurusTLS_Passphrase" /> interface


### PR DESCRIPTION
There are two extension in `ITaurusTLS_Bytes` and `ITaurusTLS_PassphraseVault`:

- Property Size added to the `ITaurusTLS_Bytes` interface. The class(es) implemented this interface and use unencrypted `TBytes` storage return the `Length` of the storage. Class(es) implemented `encrypted` storage return the length of `unencrypted` data.
- `ITaurusTLS_PassphraseVault` interface now inherits from `ITaurusTLS_Bytes` interface