### PR TITLE
Fix for functions not loading with OpenSSL 3.5.0 and changed  "introd…

### DIFF
--- a/Source/TaurusTLSHeaders_crypto.pas
+++ b/Source/TaurusTLSHeaders_crypto.pas
@@ -1010,7 +1010,7 @@ const
   OSSL_LIB_CTX_new_from_dispatch_procname = 'OSSL_LIB_CTX_new_from_dispatch';
   OSSL_LIB_CTX_new_child_procname = 'OSSL_LIB_CTX_new_child';
   OSSL_LIB_CTX_load_config_procname = 'OSSL_LIB_CTX_load_config';
-  OSSL_LIB_CTX_free_procname = '(OSSL_LIB_CTX_free';
+  OSSL_LIB_CTX_free_procname = 'OSSL_LIB_CTX_free';
   OSSL_LIB_CTX_get0_global_default_procname = 'OSSL_LIB_CTX_get0_global_default';
   OSSL_LIB_CTX_set0_default_procname = 'OSSL_LIB_CTX_set0_default';
 

--- a/Source/TaurusTLSHeaders_evp.pas
+++ b/Source/TaurusTLSHeaders_evp.pas
@@ -2956,9 +2956,9 @@ const
   EVP_Q_mac_introduced = (byte(3) shl 8 or byte(0)) shl 8 or byte(0);
   EVP_MAC_init_introduced = (byte(3) shl 8 or byte(0)) shl 8 or byte(0);
   EVP_MAC_init_SKEY_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
-  EVP_MAC_update_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
-  EVP_MAC_final_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
-  EVP_MAC_finalXOF_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
+  EVP_MAC_update_introduced = (byte(3) shl 8 or byte(0)) shl 8 or byte(0);
+  EVP_MAC_final_introduced = (byte(3) shl 8 or byte(0)) shl 8 or byte(0);
+  EVP_MAC_finalXOF_introduced = (byte(3) shl 8 or byte(0)) shl 8 or byte(0);
   EVP_MAC_CTX_get_mac_size_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
   EVP_MAC_CTX_get_block_size_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
   EVP_MAC_do_all_provided_introduced = (byte(3) shl 8 or byte(5)) shl 8 or byte(0);
@@ -3716,7 +3716,7 @@ const
 
   EVP_MAC_update_procname = 'EVP_MAC_update';
   EVP_MAC_final_procname = 'EVP_MAC_final';
-  EVP_MAC_finalXOF_procname = 'ERR_EVP_MAC_finalXOF';
+  EVP_MAC_finalXOF_procname = 'EVP_MAC_finalXOF';
 
   EVP_MAC_do_all_provided_procname = 'EVP_MAC_do_all_provided';
 


### PR DESCRIPTION
…uced" for MAC functions for accuracy.