### PR TITLE
fix: call g_VerifyCallback in TTaurusTLSSocket.Accept

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -4625,12 +4625,26 @@ procedure TTaurusTLSSocket.Accept(const pHandle: TIdStackSocketHandle);
 // Accept and Connect have a lot of duplicated code
 var
   LRetCode: Integer;
+  LFunc: SSL_verify_cb;
   // LParentIO: TTaurusTLSIOHandlerSocket;
   // LHelper: ITaurusTLSCallbackHelper;
 begin
   Assert(fSSL = nil);
   Assert(fSSLContext <> nil);
   fSSL := SSL_new(fSSLContext.Context);
+
+  if fSSLContext.VerifyOn then
+  begin
+    LFunc := g_VerifyCallback;
+  end
+  else
+  begin
+    LFunc := nil;
+  end;
+  SSL_set_verify(fSSL, TranslateInternalVerifyToSSL
+    (fSSLContext.VerifyMode), LFunc);
+  SSL_set_verify_depth(fSSL, fSSLContext.VerifyDepth);
+
   if fSSL = nil then
   begin
     raise ETaurusTLSCreatingSessionError.Create(RSSSLCreatingSessionError);


### PR DESCRIPTION
g_VerifyCallback was never actually called from TTaurusTLSIOHandlerSocket, even when OnVerifyCallback was assigned.

I added the code to TTaurusTLSSocket.Accept analogous to TTaurusTLSSocket.Connect. At first glance TTaurusTLSContext.InitContext might seem more sensible, because that code would work for both Accept and Connect, but the relevant code was already in there but commented out:
```
  if fVerifyMode <> [] then
  begin
    // SSL_CTX_set_default_verify_paths(fContext);
    { if VerifyOn then
      begin
      Func := VerifyCallback;
      end
      else
      begin
      Func := nil;
      end; }

    SSL_CTX_set_verify(fContext,
      TranslateInternalVerifyToSSL(fVerifyMode), nil);
    SSL_CTX_set_verify_depth(fContext, fVerifyDepth);
  end;

```
Thinking that was probably done for good reason, I didn't want to risk unforeseen consequences, so I didn't simply uncomment that, but thought I'd mention it here.