### PR TITLE
Workaround: disable noreturn for FPC 3.3.1

### DIFF
--- a/Source/TaurusTLS_X509.pas
+++ b/Source/TaurusTLS_X509.pas
@@ -909,11 +909,7 @@ begin
   {$IFDEF WINDOWS}
   if Assigned(IdnToUnicode) then
   begin
-    {$IFDEF UNICODE}
     Result := PunnyCodeToIDN(GetStrByNID(NID_commonName));
-    {$ELSE}
-    Result := AnsiString(PunnyCodeToIDN(GetStrByNID(NID_commonName)));
-    {$ENDIF}
   end
   else
   begin
@@ -934,11 +930,7 @@ begin
 {$IFDEF WINDOWS}
   if Assigned(IdnToUnicode) then
   begin
-    {$IFDEF UNICODE}
     Result := PunnyCodeToIDN(GetStrByNID(NID_pkcs9_emailAddress));
-    {$ELSE}
-    Result := AnsiString(PunnyCodeToIDN(GetStrByNID(NID_pkcs9_emailAddress)));
-    {$ENDIF}
   end
   else
   begin


### PR DESCRIPTION
FPC 3.3.1 (fpcupdeluxe) rejects raise inside routines declared as noreturn, failing with: "Raise in subroutines declared as noreturn is not allowed".
This change disables USE_NORETURN specifically for FPC 3.3.1 to keep Windows builds and Windows → Raspberry Pi cross-compiles working.