### PR TITLE
AV Exception and crash in UnLoadOpenSSLLibrary

### DIFF
--- a/Source/TaurusTLS.pas
+++ b/Source/TaurusTLS.pas
@@ -3193,7 +3193,6 @@ begin
   try
     if SSLIsLoaded.Value then
     begin
-      SSL_load_error_strings;
 {$IFNDEF OPENSSL_STATIC_LINK_MODEL}
       if Assigned(CRYPTO_set_locking_callback) then
 {$ENDIF}


### PR DESCRIPTION
The `SSL_load_error_strings` call in the `UnLoadOpenSSLLibrary` leads AV exception if customer code calls `IOpenSSLLoader.Unload` before.

`UnLoadOpenSSLLibrary` is called in the finalization section where exception handling is not fully available and that introduced application crash at application termination.
The `SSL_load_error_strings` is an routine exported by OpenSSL LibCrypto that dynamically linked to internal procedural variable. The `TOpenSSLLoader.Unload` method dereferences all such procedural variables.
I'm not sure the reason to include SSL_load_error_strings into `UnLoadOpenSSLLibrary` code as no OpenSSL errors can be handled there. The call to `SSL_load_error_strings` in the `UnLoadOpenSSLLibrary` was removed.